### PR TITLE
Use INFINITY macro instead of hacks

### DIFF
--- a/src/math/testmath.cpp
+++ b/src/math/testmath.cpp
@@ -1518,6 +1518,10 @@ class arc_interval_test : public Test {
 	}
 };
 
+int __isinf(double x) {
+    return fabs(x) > std::numeric_limits<double>::max();
+}
+
 class inf_and_nan_test : public Test {
     public:
 	void run() {
@@ -1526,9 +1530,9 @@ class inf_and_nan_test : public Test {
         assertTrue(std::numeric_limits<double>::infinity() == std::numeric_limits<double>::infinity());
         assertTrue(std::numeric_limits<double>::infinity() > 0);
         assertTrue(std::numeric_limits<double>::has_infinity);
-        assertTrue(isinf<double>(std::numeric_limits<double>::infinity()));
-        assertTrue(std::isinf<double>(std::numeric_limits<double>::infinity()));
-        assertTrue(std::isinf<double>(-std::numeric_limits<double>::infinity()));
+        assertTrue(__isinf(std::numeric_limits<double>::infinity()));
+        assertTrue(__isinf(std::numeric_limits<double>::infinity()));
+        assertTrue(__isinf(-std::numeric_limits<double>::infinity()));
         assertTrue(std::numeric_limits<double>::infinity() > -std::numeric_limits<double>::infinity());
     }
 };

--- a/src/math/testmath.cpp
+++ b/src/math/testmath.cpp
@@ -5,6 +5,7 @@
 
 #include <stdlib.h>
 #include <iostream>
+#include <limits>
 
 #include "vector.h"
 #include "vector2.h"

--- a/src/math/testmath.cpp
+++ b/src/math/testmath.cpp
@@ -1517,6 +1517,19 @@ class arc_interval_test : public Test {
 	}
 };
 
+class inf_and_nan_test : public Test {
+    public:
+	void run() {
+        assertFalse(NAN == NAN);
+        assertFalse(NAN > NAN);
+        assertTrue(std::numeric_limits<double>::infinity() == std::numeric_limits<double>::infinity());
+        assertTrue(std::numeric_limits<double>::infinity() > 0);
+        assertTrue(std::isinf(std::numeric_limits<double>::infinity()));
+        assertTrue(std::isinf(-std::numeric_limits<double>::infinity()));
+        assertTrue(std::numeric_limits<double>::infinity() > -std::numeric_limits<double>::infinity());
+    }
+};
+
 int main(int argc, char *argv[]) {
 
     TestSuite suite;
@@ -1544,6 +1557,7 @@ int main(int argc, char *argv[]) {
     suite.add("Interval",new interval_test());
     suite.add("Arc interval",new arc_interval_test());
     suite.add("Poisson Disc",new poisson_disc_test());
+    suite.add("Infinity and NaN",new inf_and_nan_test());
     suite.run();
     suite.printStatus();
     if (suite.hasFailures()) {

--- a/src/math/testmath.cpp
+++ b/src/math/testmath.cpp
@@ -1525,6 +1525,7 @@ class inf_and_nan_test : public Test {
         assertFalse(NAN > NAN);
         assertTrue(std::numeric_limits<double>::infinity() == std::numeric_limits<double>::infinity());
         assertTrue(std::numeric_limits<double>::infinity() > 0);
+        assertTrue(std::numeric_limits<double>::has_infinity);
         assertTrue(std::isinf(std::numeric_limits<double>::infinity()));
         assertTrue(std::isinf(-std::numeric_limits<double>::infinity()));
         assertTrue(std::numeric_limits<double>::infinity() > -std::numeric_limits<double>::infinity());

--- a/src/math/testmath.cpp
+++ b/src/math/testmath.cpp
@@ -1526,7 +1526,7 @@ class inf_and_nan_test : public Test {
         assertTrue(std::numeric_limits<double>::infinity() == std::numeric_limits<double>::infinity());
         assertTrue(std::numeric_limits<double>::infinity() > 0);
         assertTrue(std::numeric_limits<double>::has_infinity);
-        assertTrue(std::isinf<double>(std::numeric_limits<double>::infinity()));
+        assertTrue(isinf<double>(std::numeric_limits<double>::infinity()));
         assertTrue(std::isinf<double>(std::numeric_limits<double>::infinity()));
         assertTrue(std::isinf<double>(-std::numeric_limits<double>::infinity()));
         assertTrue(std::numeric_limits<double>::infinity() > -std::numeric_limits<double>::infinity());

--- a/src/math/testmath.cpp
+++ b/src/math/testmath.cpp
@@ -1526,8 +1526,9 @@ class inf_and_nan_test : public Test {
         assertTrue(std::numeric_limits<double>::infinity() == std::numeric_limits<double>::infinity());
         assertTrue(std::numeric_limits<double>::infinity() > 0);
         assertTrue(std::numeric_limits<double>::has_infinity);
-        assertTrue(std::isinf(std::numeric_limits<double>::infinity()));
-        assertTrue(std::isinf(-std::numeric_limits<double>::infinity()));
+        assertTrue(std::isinf<double>(std::numeric_limits<double>::infinity()));
+        assertTrue(std::isinf<double>(std::numeric_limits<double>::infinity()));
+        assertTrue(std::isinf<double>(-std::numeric_limits<double>::infinity()));
         assertTrue(std::numeric_limits<double>::infinity() > -std::numeric_limits<double>::infinity());
     }
 };

--- a/src/scheme/numbers.cpp
+++ b/src/scheme/numbers.cpp
@@ -7,6 +7,10 @@
 #include <cstdlib>
 #include <cstring>
 
+int __isinf(double x) {
+    return fabs(x) > std::numeric_limits<double>::max();
+}
+
 void coerceNumbers(int num, SchemeStack::iterator stack, double* dest) {
     for(int i = 0; i < num; i++) {
         *dest = scm2double(*stack);
@@ -434,7 +438,7 @@ SchemeObject* s_exp(Scheme* scheme, SchemeObject* n) {
         return complex2scm(std::exp(scm2complex(n)));
     } else {
 	double d = scm2double(n);
-	if (std::isinf(d)) {
+	if (__isinf(d)) {
 	    return double2scm(d > 0 ? std::numeric_limits<double>::infinity() : 0.0);
 	} else {
 	    return double2scm(std::exp(d));
@@ -870,7 +874,7 @@ SchemeObject* s_zero_p(Scheme* scheme, SchemeObject* n) {
 SchemeObject* s_infinite_p(Scheme* scheme, SchemeObject* n) {
     assert_arg_number_type(L"infinite?", 1, n);
     if (n->type() == SchemeObject::REAL_NUMBER) {
-	    return bool2scm(std::isinf(scm2double(n)));
+	    return bool2scm(__isinf(scm2double(n)));
     } else {
 	    return S_FALSE;
     }
@@ -879,7 +883,7 @@ SchemeObject* s_infinite_p(Scheme* scheme, SchemeObject* n) {
 SchemeObject* s_finite_p(Scheme* scheme, SchemeObject* n) {
     assert_arg_number_type(L"finite?", 1, n);
     if (n->type() == SchemeObject::REAL_NUMBER) {
-	    return bool2scm(!std::isinf(scm2double(n)));
+	    return bool2scm(!__isinf(scm2double(n)));
     } else {
 	    return S_TRUE;
     }
@@ -1137,7 +1141,7 @@ SchemeObject* i_integer_p(SchemeObject* p) {
         return bool2scm(d == 1 || d == -1);
     } else if (p->type() == SchemeObject::REAL_NUMBER) {
         double d = scm2double(p);
-        return !std::isnan(d) && !std::isinf(d) && ::modf(d,&i) == 0.0 ? S_TRUE : S_FALSE;
+        return !std::isnan(d) && !__isinf(d) && ::modf(d,&i) == 0.0 ? S_TRUE : S_FALSE;
     } else if (p->type() == SchemeObject::COMPLEX_NUMBER) {
         std::complex<double> z = p->complexValue();
         return ::modf(z.real(),&i) == 0.0 && z.imag() == 0.0 ? S_TRUE : S_FALSE;
@@ -1520,7 +1524,7 @@ wstring i_number_2_string(SchemeObject* o, uint32_t radix) {
         return ss.str();
     } else if (type == SchemeObject::REAL_NUMBER) {
         double d = scm2double(o);
-	    if (std::isinf(d)) {
+	    if (__isinf(d)) {
 	        ss << (d > 0 ? L"+inf.0" : L"-inf.0");
 	    } else if (std::isnan(d)) {
 	        ss << L"+nan.0";
@@ -1541,7 +1545,7 @@ wstring i_number_2_string(SchemeObject* o, uint32_t radix) {
             return i_number_2_string(o->real, radix);        
         } else {
             ss << i_number_2_string(o->real, radix);
-            if (o->imag->realValue() >= 0.0 && !std::isinf(o->imag->realValue())) {
+            if (o->imag->realValue() >= 0.0 && !__isinf(o->imag->realValue())) {
                 ss << L"+";        
             }
             ss << i_number_2_string(o->imag, radix);

--- a/src/scheme/numbers.cpp
+++ b/src/scheme/numbers.cpp
@@ -1270,9 +1270,9 @@ SchemeObject* i_string_2_number(Scheme* scheme, wstring s, uint32_t radix, size_
 	    return S_FALSE;
     }
     if (s == L"+inf.0") {
-	    return double2scm(-1.0 * log(0.0));
+	    return double2scm(INFINITY);
     } else if (s == L"-inf.0") {
-	    return double2scm(log(0.0));
+	    return double2scm(-INFINITY);
     } else if (s == L"+nan.0") {
         return double2scm(NAN);
     }

--- a/src/scheme/numbers.cpp
+++ b/src/scheme/numbers.cpp
@@ -435,7 +435,7 @@ SchemeObject* s_exp(Scheme* scheme, SchemeObject* n) {
     } else {
 	double d = scm2double(n);
 	if (std::isinf(d)) {
-	    return double2scm(d > 0 ? INFINITY : 0.0);
+	    return double2scm(d > 0 ? std::numeric_limits<double>::infinity() : 0.0);
 	} else {
 	    return double2scm(std::exp(d));
 	}
@@ -1270,11 +1270,11 @@ SchemeObject* i_string_2_number(Scheme* scheme, wstring s, uint32_t radix, size_
 	    return S_FALSE;
     }
     if (s == L"+inf.0") {
-	    return double2scm(INFINITY);
+	    return double2scm(std::numeric_limits<double>::infinity());
     } else if (s == L"-inf.0") {
-	    return double2scm(-INFINITY);
+	    return double2scm(-std::numeric_limits<double>::infinity());
     } else if (s == L"+nan.0") {
-        return double2scm(NAN);
+        return double2scm(std::numeric_limits<double>::quiet_NaN());
     }
 
     bool radix_prefix_seen = false;

--- a/src/scheme/numbers.cpp
+++ b/src/scheme/numbers.cpp
@@ -435,7 +435,7 @@ SchemeObject* s_exp(Scheme* scheme, SchemeObject* n) {
     } else {
 	double d = scm2double(n);
 	if (std::isinf(d)) {
-	    return double2scm(d > 0 ? -log(0.0) : 0.0);
+	    return double2scm(d > 0 ? INFINITY : 0.0);
 	} else {
 	    return double2scm(std::exp(d));
 	}


### PR DESCRIPTION
Trying to make unit tests run on Travis CI.

`-1.0 * log(0.0)` was INFINITY and `log(0.0)` was -INFINITY.