### PR TITLE
Fix macOS ARM test build

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -21,7 +21,7 @@ else
 fi
 
 echo "Now running automake"
-automake --add-missing 
+automake --add-missing --copy --force-missing
 
 echo "Now running autoconf"
 autoconf
@@ -31,4 +31,3 @@ echo "Now running configure"
 $srcdir/configure $*
 
 echo "Type make to build raygay"
-

--- a/configure.ac
+++ b/configure.ac
@@ -138,7 +138,7 @@ fi
 dnl -------------------------------------------------
 dnl Add the CPU dependent compile optimizations
 dnl -------------------------------------------------
-CXXFLAGS="-g -O3 -Wall -Winline -ffast-math $GTK_CFLAGS $GUILE_CFLAGS $CXXFLAGS"  
+CXXFLAGS="-g -O3 -Wall -Winline $GTK_CFLAGS $GUILE_CFLAGS $CXXFLAGS"  
 case $target in
      pentium3) CXXFLAGS="$CXXFLAGS -malign-double -march=pentium3 -mfpmath=sse -ftracer -mno-ieee-fp -fstrict-aliasing";;
      pentium4) CXXFLAGS="$CXXFLAGS -fprefetch-loop-arrays -funroll-loops -malign-double -fomit-frame-pointer -march=pentium4 -mfpmath=sse -ftracer -mno-ieee-fp -fstrict-aliasing -msse2";;
@@ -225,5 +225,4 @@ echo
 echo "Where <cpu> can be: pentium3, pentiu4, g4"
 echo 
 echo "--------------------------------------------------------------"
-
 


### PR DESCRIPTION
## Summary
- remove the default -ffast-math build flag so IEEE infinity/NaN behavior remains available on Apple Silicon
- make autogen.sh copy automake helper scripts instead of creating brittle symlinks into a Homebrew Cellar version

## Verification
- ./autogen.sh
- make clean
- make check

Results on Darwin arm64:
- src/math: 1/1 pass
- src/scheme: 2/2 pass
- test: 8/8 pass