### PR TITLE
Fix root buffer bounds declarations

### DIFF
--- a/src/objects/cone.h
+++ b/src/objects/cone.h
@@ -38,7 +38,7 @@ private:
   double _fastIntersect(const Ray &ray) const;
   void _fullIntersect(const Ray &ray, const double t,
                       Intersection &result) const;
-  uint32_t allPositiveRoots(const Ray &world_ray, double roots[4]) const;
+  uint32_t allPositiveRoots(const Ray &world_ray, double roots[2]) const;
   Vector getNormal(const Vector &local_point) const;
 
   Vector begin;

--- a/src/objects/cylinder.h
+++ b/src/objects/cylinder.h
@@ -44,7 +44,7 @@ private:
   double _fastIntersect(const Ray &ray) const;
   void _fullIntersect(const Ray &ray, const double t,
                       Intersection &result) const;
-  uint32_t allPositiveRoots(const Ray &world_ray, double roots[4]) const;
+  uint32_t allPositiveRoots(const Ray &world_ray, double roots[2]) const;
   Vector getNormal(const Vector &local_point) const;
 
   double radius;


### PR DESCRIPTION
## Summary
- align Cone::allPositiveRoots and Cylinder::allPositiveRoots header declarations with their definitions
- document the private root buffer contract as two entries, matching callers and maxIntersections()

## Verification
- make -C src/objects cone.lo cylinder.lo
- make -C test check TESTS=testobjects

Fixes #8