### PR TITLE
Modernize deprecated API usage

### DIFF
--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -55,10 +55,9 @@ void *Allocator::safe_allocate(size_t size, model_t type) {
 
 void *Allocator::allocate_mmap(size_t size) {
   int res, file;
-  char templ[50] = "";
+  char templ[] = "/tmp/tracer-XXXXXX";
 
   // TODO: Lookup env TMPDIR for prefix below
-  sprintf(templ, "%s", "/tmp/tracer-XXXXXX");
   file = ::mkstemp(templ);
 
   if (Environment::getUniqueInstance()->isVerbose()) {

--- a/src/collections/caseinsensitive_map.h
+++ b/src/collections/caseinsensitive_map.h
@@ -4,10 +4,9 @@
 
 #include <cctype>
 #include <map>
+#include <string>
 
-class ignorecase_comparator
-    : public std::binary_function<const std::string &, const std::string &,
-                                  bool> {
+class ignorecase_comparator {
 public:
   bool operator()(const std::string &str1, const std::string &str2) const {
     std::string::size_type max =

--- a/src/http/imageresponse.cpp
+++ b/src/http/imageresponse.cpp
@@ -1,14 +1,28 @@
 
 #include "http/imageresponse.h"
+#include "exception.h"
 #include "image/image.h"
 #include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <unistd.h>
 
 ImageResponse::ImageResponse(Image *image) : HTTPResponse(200, "image/png") {
-  char filename[L_tmpnam + 1];
-  char *ptr;
-  ptr = mktemp(filename);
-  image->save(string(ptr) + ".png");
-  FILE *f = ::fopen(ptr, "r");
+  char templ[] = "/tmp/raygay-image-XXXXXX";
+  int fd = ::mkstemp(templ);
+  if (fd == -1) {
+    throw_exception("Could not create temporary image file");
+  }
+  ::close(fd);
+  ::remove(templ);
+
+  string filename = string(templ) + ".png";
+  image->save(filename);
+  FILE *f = ::fopen(filename.c_str(), "rb");
+  ::remove(filename.c_str());
+  if (f == NULL) {
+    throw_exception("Could not open temporary image file");
+  }
   this->setBody(f);
 };
 

--- a/src/image/imageio_darwin.cpp
+++ b/src/image/imageio_darwin.cpp
@@ -145,15 +145,15 @@ Image *DarwinIO::load(const std::string &filename, Allocator::model_t model) {
 
 CFStringRef DarwinIO::filenameToUTI(const string &filename) const {
   if (filename.find(".png") != string::npos) {
-    return kUTTypePNG;
+    return CFSTR("public.png");
   } else if (filename.find(".jpg") != string::npos ||
              filename.find(".jpeg") != string::npos) {
-    return kUTTypeJPEG;
+    return CFSTR("public.jpeg");
   } else if (filename.find(".jp2") != string::npos) {
-    return kUTTypeJPEG2000;
+    return CFSTR("public.jpeg-2000");
   } else if (filename.find(".tif") != string::npos ||
              filename.find(".tiff") != string::npos) {
-    return kUTTypeTIFF;
+    return CFSTR("public.tiff");
   } else {
     throw_exception(filename + " has unknown fileformat.");
   }

--- a/src/objects/mesh.cpp
+++ b/src/objects/mesh.cpp
@@ -3,6 +3,7 @@
 #include <cstdio>
 #include <iostream>
 #include <map>
+#include <string>
 #include <vector>
 
 #include "exception.h"
@@ -262,9 +263,8 @@ void Mesh::addTriangle(const uint32_t v[3], const uint32_t uv[3],
                        const uint32_t n[3]) {
   uint32_t max_idx = corners.size() - 1;
   if (v[0] > max_idx || v[1] > max_idx || v[2] > max_idx) {
-    char vs[200];
-    sprintf(vs, "Triangle (%d,%d,%d) out of bounds", v[0], v[1], v[2]);
-    throw_exception(vs);
+    throw_exception("Triangle (" + to_string(v[0]) + "," + to_string(v[1]) +
+                    "," + to_string(v[2]) + ") out of bounds");
   }
   faces.push_back(v[0]);
   faces.push_back(v[1]);
@@ -298,9 +298,8 @@ void Mesh::addTriangle(const uint32_t v[3], const Vector2 uv[3]) {
     uint32_t max_idx = corners.size() - 1;
     if (v[0] > max_idx || v[1] > max_idx || v[2] > max_idx ||
         v[0] < 0 || v[1] < 0 || v[2] < 0) {
-        char vs[200];
-        sprintf(vs, "Triangle (%d,%d,%d) out of bounds",v[0],v[1],v[2]);
-        throw_exception(vs);
+        throw_exception("Triangle (" + to_string(v[0]) + "," + to_string(v[1]) +
+                        "," + to_string(v[2]) + ") out of bounds");
     }
 
     faces.push_back(v[0]);

--- a/src/testing.h
+++ b/src/testing.h
@@ -109,12 +109,10 @@ void Test::_assertTrue(bool expr, const char *filename, int line,
   if (expr) {
     succeded_asserts++;
   } else {
-    char line_c[10];
-    sprintf(line_c, "%d", line);
     string error_text = "Failed test: ";
     error_text += string(filename);
     error_text += ":";
-    error_text += string(line_c);
+    error_text += to_string(line);
     error_text += ":";
     error_text += string(expr_code);
     failed_output.push_back(error_text);

--- a/src/window-gtk.cpp
+++ b/src/window-gtk.cpp
@@ -13,6 +13,7 @@
 #include <glib.h>
 #include <iostream>
 #include <pthread.h>
+#include <string>
 
 int darea_width;
 int darea_height;
@@ -148,9 +149,8 @@ void PreviewWindowGTK::setProgress(double progress) {
     gdk_threads_enter();
     gtk_progress_bar_set_fraction(progress_bar, progress);
     int p = int(100.0 * progress);
-    char title[1000];
-    sprintf(title, "RayGay (%d%%)", p);
-    gtk_window_set_title(GTK_WINDOW(window), title);
+    std::string title = "RayGay (" + std::to_string(p) + "%)";
+    gtk_window_set_title(GTK_WINDOW(window), title.c_str());
     gdk_flush();
     gdk_threads_leave();
   }

--- a/test/testing.h
+++ b/test/testing.h
@@ -110,12 +110,10 @@ void Test::_assertTrue(bool expr, const char *filename, int line,
   if (expr) {
     succeded_asserts++;
   } else {
-    char line_c[10];
-    sprintf(line_c, "%d", line);
     string error_text = "Failed test: ";
     error_text += string(filename);
     error_text += ":";
-    error_text += string(line_c);
+    error_text += to_string(line);
     error_text += ":";
     error_text += string(expr_code);
     failed_output.push_back(error_text);


### PR DESCRIPTION
## Summary
- replace deprecated sprintf use in C++ test/mesh/window/allocator code paths
- replace ImageResponse mktemp usage with mkstemp-based temporary PNG handling
- stop using deprecated kUTType* constants in Darwin image output
- remove deprecated std::binary_function inheritance from case-insensitive map comparator

## Verification
- make
- make check

Results on macOS arm64:
- src/math: 1/1 pass
- src/scheme: 2/2 pass
- test: 8/8 pass

Fixes #10