### PR TITLE
Replace C++ variable length arrays

### DIFF
--- a/src/gzip.cpp
+++ b/src/gzip.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <vector>
 
 using namespace std;
 
@@ -159,25 +160,26 @@ void GZIP::process_dynamic_huffman_block() {
 
   // Create the dynamic lit-len and dist alphabets using the
   // code_length_alphabet
-  alphabet_t joined_alphabet[HLIT + HDIST];
-  clear_alphabet(joined_alphabet, HLIT + HDIST - 1);
-  create_code_length_encoded_alphabet(joined_alphabet, HLIT + HDIST,
+  vector<alphabet_t> joined_alphabet(HLIT + HDIST);
+  clear_alphabet(joined_alphabet.data(), HLIT + HDIST - 1);
+  create_code_length_encoded_alphabet(joined_alphabet.data(), HLIT + HDIST,
                                       code_length_tree);
 
   if (joined_alphabet[256].len == 0) {
     error("The end-of-block code must have non-zero bitlength.");
   }
 
-  expand_alphabet(joined_alphabet, HLIT - 1);
-  expand_alphabet(joined_alphabet + HLIT, HDIST);
+  expand_alphabet(joined_alphabet.data(), HLIT - 1);
+  expand_alphabet(joined_alphabet.data() + HLIT, HDIST);
 
   // Create the dynamic lit-len and dist trees using the corresponding alphabets
-  tree_t dynamic_lit_tree[HLIT * 3];
-  tree_t dynamic_dist_tree[HDIST * 3];
-  create_tree(dynamic_lit_tree, joined_alphabet, HLIT - 1);
-  create_tree(dynamic_dist_tree, joined_alphabet + HLIT, HDIST - 1);
+  vector<tree_t> dynamic_lit_tree(HLIT * 3);
+  vector<tree_t> dynamic_dist_tree(HDIST * 3);
+  create_tree(dynamic_lit_tree.data(), joined_alphabet.data(), HLIT - 1);
+  create_tree(dynamic_dist_tree.data(), joined_alphabet.data() + HLIT,
+              HDIST - 1);
 
-  process_huffman_block(dynamic_lit_tree, dynamic_dist_tree);
+  process_huffman_block(dynamic_lit_tree.data(), dynamic_dist_tree.data());
 }
 
 uint8_t len_extra_bits[] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2,
@@ -321,13 +323,12 @@ void GZIP::expand_alphabet(GZIP::alphabet_t *tree, uint32_t max_code) {
     }
   }
 
-  uint32_t bl_count[max_bits];
-  std::fill_n(bl_count, max_bits, 0);
+  vector<uint32_t> bl_count(max_bits + 1, 0);
   for (uint32_t i = 0; i <= max_code; i++) {
     bl_count[tree[i].len]++;
   }
 
-  uint32_t next_code[max_bits];
+  vector<uint32_t> next_code(max_bits + 1);
   uint32_t code = 0;
   for (uint32_t bits = 1; bits <= max_bits; bits++) {
     code = (code + bl_count[bits - 1]) << 1;

--- a/src/imagefilters/gaussianblur.cpp
+++ b/src/imagefilters/gaussianblur.cpp
@@ -2,6 +2,7 @@
 #include "imagefilters/gaussianblur.h"
 #include "image/image.h"
 #include <cassert>
+#include <vector>
 
 using namespace std;
 
@@ -14,7 +15,7 @@ void GaussianBlur::apply(Image *image) {
 
   int h = (int)radius;
 
-  double mask[h + 1];
+  vector<double> mask(h + 1);
 
   int h2 = h / 2;
 
@@ -25,7 +26,7 @@ void GaussianBlur::apply(Image *image) {
     mask[x + h2] = val;
   }
 
-  normalizeMask(mask, h + 1, 1);
+  normalizeMask(mask.data(), h + 1, 1);
 
-  applyMask(image, mask, h, h, ImageFilter::WRAP_EDGES);
+  applyMask(image, mask.data(), h, h, ImageFilter::WRAP_EDGES);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -329,8 +329,8 @@ void render_frame(string outputfile, int jobs) {
     delete renderer;
   } else {
     // Spawn renderer threads
-    Renderer *renderers[renderersettings->threads_num];
-    pthread_t threads[renderersettings->threads_num];
+    vector<Renderer *> renderers(renderersettings->threads_num);
+    vector<pthread_t> threads(renderersettings->threads_num);
     for (int i = 0; i < renderersettings->threads_num; i++) {
       switch (renderersettings->renderertype) {
       case RendererSettings::PHOTON_RENDERER:

--- a/src/math/polynomial.cpp
+++ b/src/math/polynomial.cpp
@@ -13,6 +13,16 @@ Polynomial::Polynomial() {
 
 Polynomial::Polynomial(const Polynomial &other) { init(other); }
 
+Polynomial::Polynomial(uint32_t num, Uninitialized) {
+  assert(num >= 1);
+  this->num = num;
+  if (num < MAX_INLINE_COEFFS) {
+    coefficients = coefficients_inline;
+  } else {
+    coefficients = new double[num];
+  }
+}
+
 Polynomial::Polynomial(double *coefficients, uint32_t num) {
   assert(num >= 1);
   if (num < MAX_INLINE_COEFFS) {
@@ -102,11 +112,12 @@ Polynomial Polynomial::derivative() const {
   if (num == 1)
     return Polynomial(0.0);
 
-  double c[num - 1];
+  Polynomial result(num - 1, Uninitialized());
   for (uint32_t i = 1; i < num; i++) {
-    c[i - 1] = coefficients[i] * i;
+    result.coefficients[i - 1] = coefficients[i] * i;
   }
-  return Polynomial(c, num - 1);
+  result.reduce();
+  return result;
 }
 
 bool Polynomial::operator==(const Polynomial &p) const {
@@ -121,47 +132,51 @@ bool Polynomial::operator==(const Polynomial &p) const {
 
 Polynomial Polynomial::operator+(const Polynomial &p) const {
   uint32_t new_num = MAX(p.num, num);
-  double new_coefs[new_num];
+  Polynomial result(new_num, Uninitialized());
   for (uint32_t i = 0; i < new_num; i++) {
     double q = 0.0;
     if (i < num)
       q += coefficients[i];
     if (i < p.num)
       q += p.coefficients[i];
-    new_coefs[i] = q;
+    result.coefficients[i] = q;
   }
-  return Polynomial(new_coefs, new_num);
+  result.reduce();
+  return result;
 }
 
 Polynomial Polynomial::operator-(const Polynomial &p) const {
   uint32_t new_num = MAX(p.num, num);
-  double new_coefs[new_num];
+  Polynomial result(new_num, Uninitialized());
   for (uint32_t i = 0; i < new_num; i++) {
     double q = 0.0;
     if (i < num)
       q += coefficients[i];
     if (i < p.num)
       q -= p.coefficients[i];
-    new_coefs[i] = q;
+    result.coefficients[i] = q;
   }
-  return Polynomial(new_coefs, new_num);
+  result.reduce();
+  return result;
 }
 
 Polynomial Polynomial::operator*(double c) const {
-  double new_coefs[num];
+  Polynomial result(num, Uninitialized());
   for (uint32_t i = 0; i < num; i++) {
-    new_coefs[i] = coefficients[i] * c;
+    result.coefficients[i] = coefficients[i] * c;
   }
-  return Polynomial(new_coefs, num);
+  result.reduce();
+  return result;
 }
 
 Polynomial Polynomial::operator/(double c) const {
   assert(IS_NZERO(c));
-  double new_coefs[num];
+  Polynomial result(num, Uninitialized());
   for (uint32_t i = 0; i < num; i++) {
-    new_coefs[i] = coefficients[i] / c;
+    result.coefficients[i] = coefficients[i] / c;
   }
-  return Polynomial(new_coefs, num);
+  result.reduce();
+  return result;
 }
 
 /**
@@ -172,15 +187,16 @@ Polynomial Polynomial::operator/(double c) const {
  * @return the \f$ g(x) \f$ above.
  */
 Polynomial Polynomial::timesX(uint32_t d) const {
-  double new_coefficients[num + d];
+  Polynomial result(num + d, Uninitialized());
   for (uint32_t i = 0; i < num + d; i++) {
     if (i < d) {
-      new_coefficients[i] = 0.0;
+      result.coefficients[i] = 0.0;
     } else {
-      new_coefficients[i] = coefficients[i - d];
+      result.coefficients[i] = coefficients[i - d];
     }
   }
-  return Polynomial(new_coefficients, num + d);
+  result.reduce();
+  return result;
 }
 
 double Polynomial::leadingCoefficient() const { return coefficients[num - 1]; }
@@ -211,9 +227,9 @@ Polynomial Polynomial::division(const Polynomial &divisor,
     return *this / divisor.coefficient(0);
   }
 
-  double quotient_coeffs[num];
+  Polynomial quotient(num, Uninitialized());
   for (uint32_t i = 0; i < num; i++)
-    quotient_coeffs[i] = 0.0;
+    quotient.coefficients[i] = 0.0;
 
   double div_lead_q = divisor.leadingCoefficient();
   uint32_t div_lead_d = divisor.order();
@@ -223,13 +239,14 @@ Polynomial Polynomial::division(const Polynomial &divisor,
   do {
     uint32_t new_d = remainder.order() - div_lead_d;
     double new_q = remainder.leadingCoefficient() / div_lead_q;
-    quotient_coeffs[new_d] = new_q;
+    quotient.coefficients[new_d] = new_q;
     Polynomial remainder_2 = divisor.timesX(new_d) * new_q;
     remainder = remainder - remainder_2;
   } while (remainder.order() >= div_lead_d);
 
   remainder.reduce();
-  return Polynomial(quotient_coeffs, num);
+  quotient.reduce();
+  return quotient;
 }
 
 /**
@@ -242,19 +259,20 @@ void Polynomial::reduce() {
 }
 
 Polynomial Polynomial::operator*(const Polynomial &other) const {
-  double result_coeffs[num + other.num];
+  Polynomial result(num + other.num, Uninitialized());
 
   for (uint32_t i = 0; i < num + other.num; i++) {
-    result_coeffs[i] = 0.0;
+    result.coefficients[i] = 0.0;
   }
 
   for (uint32_t i = 0; i < num; i++) {
     for (uint32_t j = 0; j < other.num; j++) {
-      result_coeffs[i + j] += other.coefficients[j] * coefficients[i];
+      result.coefficients[i + j] += other.coefficients[j] * coefficients[i];
     }
   }
 
-  return Polynomial(result_coeffs, num + other.num);
+  result.reduce();
+  return result;
 }
 
 Polynomial &Polynomial::operator=(const Polynomial &other) {

--- a/src/math/polynomial.h
+++ b/src/math/polynomial.h
@@ -72,6 +72,8 @@ public:
   double coefficient(uint32_t i) const { return coefficients[i]; };
 
 private:
+  struct Uninitialized {};
+  Polynomial(uint32_t num, Uninitialized);
   void init(const Polynomial &other);
   void reduce();
 

--- a/src/math/sturmsequence.cpp
+++ b/src/math/sturmsequence.cpp
@@ -2,6 +2,7 @@
 #include "math/sturmsequence.h"
 #include <cassert>
 #include <iostream>
+#include <vector>
 
 SturmSequence::SturmSequence(const Polynomial &polynomial) {
   assert(f.size() == 0);
@@ -30,8 +31,8 @@ void SturmSequence::eval(double x, double *dest) const {
 int SturmSequence::signChanges(double x) const {
   uint32_t num = f.size() - 1; // Ignore last polynomial that is constant 0.
 
-  double values[num];
-  eval(x, values);
+  std::vector<double> values(f.size());
+  eval(x, values.data());
 
   uint32_t result = 0;
   for (uint32_t i = 1; i < num; i++) {

--- a/src/parser/sceneobjectfactory.cpp
+++ b/src/parser/sceneobjectfactory.cpp
@@ -33,6 +33,8 @@
 #include "parser/schemeisosurface.h"
 #include "parser/schemeparametrizedsurface.h"
 
+#include <vector>
+
 Scheme *SceneObjectFactory::scheme;
 
 SchemeObject *s_sceneobject_p(Scheme *scheme, SchemeObject *object) {
@@ -394,19 +396,19 @@ SchemeObject *make_mesh(Scheme *scheme, SchemeObject *s_material,
       SchemeObject *s_triangle = s_list_ref(scheme, s_triangles, int2scm(i));
       if (scm2bool(i_vector_p(s_triangle))) {
         int num = i_vector_length(s_triangle);
-        uint32_t v[num];
+        std::vector<uint32_t> v(num);
         for (int j = 0; j < num; j++) {
           v[j] = safe_scm2int(i_vector_ref(s_triangle, j), 2, proc);
         }
-        mesh->addConvexPolygon(num, v);
+        mesh->addConvexPolygon(num, v.data());
       } else if (scm2bool(i_list_p(s_triangle))) {
         int num = i_length(s_triangle);
-        uint32_t v[num];
+        std::vector<uint32_t> v(num);
         for (int j = 0; j < num; j++) {
           v[j] =
               safe_scm2int(s_list_ref(scheme, s_triangle, int2scm(j)), 2, proc);
         }
-        mesh->addConvexPolygon(num, v);
+        mesh->addConvexPolygon(num, v.data());
       } else {
         wrong_type_arg(proc, 2, s_triangle);
       }

--- a/src/photon/globalphotonmap.cpp
+++ b/src/photon/globalphotonmap.cpp
@@ -4,6 +4,7 @@
 #include "photon/globalphotonmap.h"
 #include "stats.h"
 #include <pthread.h>
+#include <vector>
 
 /**
  * This is the constructor for the global photon map.
@@ -73,8 +74,8 @@ void *preComputeIrradianceThread(void *thread_data) {
 void GlobalPhotonMap::preComputeIrradiances(const int M, int threads_num) {
   assert(M >= 1);
   assert(threads_num >= 1);
-  struct thread_data *ta = new thread_data[threads_num];
-  pthread_t threads[threads_num];
+  std::vector<thread_data> ta(threads_num);
+  std::vector<pthread_t> threads(threads_num);
 
   for (int i = 0; i < threads_num; i++) {
     ta[i].map = this;
@@ -86,7 +87,6 @@ void GlobalPhotonMap::preComputeIrradiances(const int M, int threads_num) {
   for (int i = 0; i < threads_num; i++) {
     pthread_join(threads[i], NULL);
   }
-  delete[] ta;
 }
 
 /**

--- a/src/photon/photontracer.cpp
+++ b/src/photon/photontracer.cpp
@@ -62,7 +62,7 @@ void PhotonTracer::printProgress() {
 }
 
 void PhotonTracer::trace(int threads_num) {
-  pthread_t threads[threads_num];
+  vector<pthread_t> threads(threads_num);
   // Spawn threads
   for (int i = 0; i < threads_num; i++) {
     pthread_create(&threads[i], NULL, threadDo, this);

--- a/src/queuemanager-main.cpp
+++ b/src/queuemanager-main.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <iostream>
 #include <unistd.h>
+#include <vector>
 
 extern "C" {
 #include <fcntl.h>
@@ -141,7 +142,7 @@ QueueMaster::QueueMaster(set<string> hosts, vector<QueueJob> jobs) {
 
 void QueueMaster::run() {
   uint32_t threads_num = hosts.size();
-  pthread_t threads[threads_num];
+  vector<pthread_t> threads(threads_num);
   int j = 0;
   for (set<string>::iterator i = hosts.begin(); i != hosts.end(); i++) {
     QueueSlave *slave;

--- a/src/scheme/filenames.cpp
+++ b/src/scheme/filenames.cpp
@@ -1,19 +1,20 @@
 
 #include "filenames.h"
 #include <cstdlib>
+#include <vector>
 
 std::string SchemeFilenames::toFilename(std::wstring str) {
   size_t length = str.size();
-  char cstring[length * 5 + 1];
+  std::vector<char> cstring(length * 5 + 1);
   const wchar_t *s = str.c_str();
-  size_t size = ::wcsrtombs(cstring, &s, 5 * length + 1, NULL);
+  size_t size = ::wcsrtombs(cstring.data(), &s, 5 * length + 1, NULL);
   cstring[size] = 0;
-  return std::string(cstring);
+  return std::string(cstring.data());
 }
 
 std::wstring SchemeFilenames::toString(std::string s) {
   size_t length = s.size();
-  wchar_t wcstring[length + 1];
-  ::mbstowcs(wcstring, s.c_str(), length + 1);
-  return std::wstring(wcstring);
+  std::vector<wchar_t> wcstring(length + 1);
+  ::mbstowcs(wcstring.data(), s.c_str(), length + 1);
+  return std::wstring(wcstring.data());
 }

--- a/src/scheme/heap.cpp
+++ b/src/scheme/heap.cpp
@@ -202,7 +202,7 @@ void Heap::dumpStats() {
 
   // Dump symbols hash distributions
   cout << "Symbols hash distribution" << endl;
-  uint32_t bits = 8;
+  static const uint32_t bits = 8;
   int bit_cor[bits]; // Bit correlations
   vector<SchemeObject *>::iterator banks_iterator = banks.begin();
   int hashes = 0;

--- a/src/scheme/interpreter.cpp
+++ b/src/scheme/interpreter.cpp
@@ -4,6 +4,7 @@
 #include "scheme.h"
 
 #include <iostream>
+#include <vector>
 
 using namespace std;
 
@@ -861,7 +862,7 @@ fn_ptr eval_built_in_procedure_call(Interpreter::State *state) {
       result = (*((SchemeObject * (*)(Scheme *, int, SchemeStack::iterator))(
           proc->fn)))(scheme, num, stack_iter);
     } else {
-      SchemeObject *argsv[num];
+      vector<SchemeObject *> argsv(num);
       for (int i = 0; i < num; i++) {
         argsv[i] = *stack_iter;
         stack_iter++;
@@ -1018,7 +1019,7 @@ fn_ptr eval_procedure_call(Interpreter::State *state) {
         result = (*((SchemeObject * (*)(Scheme *, int, SchemeStack::iterator))(
             proc->fn)))(scheme, num, stack_iter);
       } else {
-        SchemeObject *argsv[num];
+        vector<SchemeObject *> argsv(num);
         for (int i = 0; i < num; i++) {
           argsv[i] = *stack_iter;
           stack_iter++;
@@ -1479,8 +1480,8 @@ fn_ptr eval_do(Interpreter::State *state) {
     binding_pairs_ptr = i_cdr(binding_pairs_ptr);
   }
 
-  SchemeObject *varnames[bindings_num];
-  SchemeObject *steps[bindings_num];
+  vector<SchemeObject *> varnames(bindings_num);
+  vector<SchemeObject *> steps(bindings_num);
 
   binding_pairs_ptr = binding_pairs;
   for (uint32_t i = 0; i < bindings_num; i++) {

--- a/src/scheme/r6rs-lib-hashtables.cpp
+++ b/src/scheme/r6rs-lib-hashtables.cpp
@@ -1,6 +1,7 @@
 
 #include "r6rs-lib-hashtables.h"
 #include "numbers.h"
+#include <vector>
 
 #define DEFAULT_INITIAL_CAPACITY 16
 
@@ -232,7 +233,7 @@ void i_hashtable_resize(Scheme *scheme, SchemeObject *hashtable) {
 
   // cout << "Resizing hash to size " << new_buckets_num << endl;
   SchemeObject *hash_func = i_car(hashtable->s_hashtable_meta);
-  int64_t hashes[entries_num];
+  vector<int64_t> hashes(entries_num);
   int64_t index = 0;
 
   // First find all the hashes. We do this before building the new bucket-lists

--- a/src/scheme/r6rs-lib-io-ports.cpp
+++ b/src/scheme/r6rs-lib-io-ports.cpp
@@ -1,5 +1,6 @@
 
 #include <fstream>
+#include <vector>
 
 #include "filenames.h"
 #include "numbers.h"
@@ -295,7 +296,7 @@ SchemeObject *s_get_string_n(Scheme *scheme, SchemeObject *port,
   if (n == 0) {
     return string2scm(wstring(L""));
   }
-  wchar_t chars[n + 1];
+  std::vector<wchar_t> chars(n + 1);
   int32_t i;
   for (i = 0; i < n; i++) {
     wchar_t c = i_get_char(port);
@@ -305,7 +306,7 @@ SchemeObject *s_get_string_n(Scheme *scheme, SchemeObject *port,
     chars[i] = c;
   }
   chars[i] = 0;
-  return i == 0 ? S_EOF : string2scm(wstring(chars, n));
+  return i == 0 ? S_EOF : string2scm(wstring(chars.data(), n));
 }
 
 SchemeObject *s_get_string_all(Scheme *scheme, SchemeObject *port) {

--- a/src/scheme/r6rs-lib-lists.cpp
+++ b/src/scheme/r6rs-lib-lists.cpp
@@ -1,6 +1,8 @@
 
 #include "r6rs-lib-lists.h"
 
+#include <vector>
+
 SchemeObject *s_find(Scheme *scheme, SchemeObject *proc, SchemeObject *list) {
   while (list != S_EMPTY_LIST) {
     if (scheme->callProcedure_1(proc, i_car(list)) != S_FALSE) {
@@ -19,7 +21,7 @@ SchemeObject *s_for_all(Scheme *scheme, int num, SchemeStack::iterator args) {
   assert_arg_procedure_type(procname, 1, proc);
 
   int empty = 0;
-  SchemeObject *cropped_args[num - 1];
+  vector<SchemeObject *> cropped_args(num - 1);
   for (int i = 1; i < num; i++) {
     assert_non_atom_type(procname, i, args[i]);
     cropped_args[i - 1] = args[i];
@@ -70,7 +72,7 @@ SchemeObject *s_exists(Scheme *scheme, int num, SchemeStack::iterator args) {
   assert_arg_procedure_type(procname, 1, proc);
 
   int empty = 0;
-  SchemeObject *cropped_args[num - 1];
+  vector<SchemeObject *> cropped_args(num - 1);
   for (int i = 1; i < num; i++) {
     assert_non_atom_type(procname, i, args[i]);
     cropped_args[i - 1] = args[i];
@@ -159,7 +161,7 @@ SchemeObject *s_fold_left(Scheme *scheme, int num, SchemeStack::iterator args) {
 
   SchemeObject *nil = args[1];
 
-  SchemeObject *cropped_args[num - 2];
+  vector<SchemeObject *> cropped_args(num - 2);
   for (int i = 2; i < num; i++) {
     assert_non_atom_type(procname, i, args[i]);
     cropped_args[i - 2] = args[i];
@@ -203,7 +205,7 @@ SchemeObject *s_fold_right(Scheme *scheme, int num,
 
   SchemeObject *nil = args[1];
 
-  SchemeObject *cropped_args[num - 2];
+  vector<SchemeObject *> cropped_args(num - 2);
   for (int i = 2; i < num; i++) {
     assert_non_atom_type(procname, i, args[i]);
     cropped_args[i - 2] = args[i];
@@ -220,10 +222,10 @@ SchemeObject *s_fold_right(Scheme *scheme, int num,
 
   // Kopier alle argument til en tabel. Vender desuden rækkefølgen
   // på listernes indhold.
-  SchemeObject *args_table[num - 2][length];
+  vector<SchemeObject *> args_table((num - 2) * length);
   for (int i = 0; i < num - 2; i++) {
     for (int64_t j = 0; j < length; j++) {
-      args_table[i][length - j - 1] = i_car(cropped_args[i]);
+      args_table[i * length + length - j - 1] = i_car(cropped_args[i]);
       cropped_args[i] = i_cdr(cropped_args[i]);
     }
   }
@@ -233,7 +235,7 @@ SchemeObject *s_fold_right(Scheme *scheme, int num,
   for (int j = 0; j < length; j++) {
     SchemeAppendableList collection;
     for (int i = 0; i < num - 2; i++) {
-      SchemeObject *o = args_table[i][j];
+      SchemeObject *o = args_table[i * length + j];
       collection.add(o);
     }
     collection.add(nil);

--- a/src/scheme/r6rs-lib-sorting.cpp
+++ b/src/scheme/r6rs-lib-sorting.cpp
@@ -1,6 +1,8 @@
 
 #include "r6rs-lib-sorting.h"
 
+#include <vector>
+
 // Skift til mergesort. Java og Perl bruger mergesort.
 //
 // As of Perl 5.8, merge sort is its default sorting algorithm
@@ -47,8 +49,8 @@ void mergesort(Scheme *scheme, SchemeObject *proc, SchemeObject **array,
 SchemeObject *s_vector_sort_e(Scheme *scheme, SchemeObject *proc,
                               SchemeObject *vec) {
   //    assert_arg_procedure_that_take(L"vector-sort!", 1, proc, 2);
-  SchemeObject *tmp[vec->length];
-  mergesort(scheme, proc, vec->elems, vec->length, tmp);
+  std::vector<SchemeObject *> tmp(vec->length);
+  mergesort(scheme, proc, vec->elems, vec->length, tmp.data());
   return S_UNSPECIFIED;
 }
 
@@ -56,13 +58,13 @@ SchemeObject *s_list_sort(Scheme *scheme, SchemeObject *proc,
                           SchemeObject *list) {
   //    assert_arg_procedure_that_take(L"list-sort", 1, proc, 2);
   int64_t len = scm2int(s_length(scheme, list));
-  SchemeObject *vec[len];
-  SchemeObject *tmp[len];
+  std::vector<SchemeObject *> vec(len);
+  std::vector<SchemeObject *> tmp(len);
   for (int64_t i = 0; i < len; i++) {
     vec[i] = i_car(list);
     list = i_cdr(list);
   }
-  mergesort(scheme, proc, vec, len, tmp);
+  mergesort(scheme, proc, vec.data(), len, tmp.data());
   SchemeObject *result = S_EMPTY_LIST;
   for (int64_t i = 0; i < len; i++) {
     result = i_cons(vec[len - 1 - i], result);
@@ -75,11 +77,11 @@ SchemeObject *s_vector_sort(Scheme *scheme, SchemeObject *proc,
   // TODO: The check below doesn't work for user-defined lambdas.
   //    assert_arg_procedure_that_take(L"vector-sort", 1, proc, 2);
   SchemeObject **vect = new SchemeObject *[vec->length];
-  SchemeObject *tmp[vec->length];
+  std::vector<SchemeObject *> tmp(vec->length);
   for (uint32_t i = 0; i < vec->length; i++) {
     vect[i] = vec->getVectorElem(i);
   }
-  mergesort(scheme, proc, vect, vec->length, tmp);
+  mergesort(scheme, proc, vect, vec->length, tmp.data());
   return SchemeObject::createVector(vect, vec->length);
 }
 

--- a/src/scheme/r6rs-lib-unicode.cpp
+++ b/src/scheme/r6rs-lib-unicode.cpp
@@ -3,6 +3,8 @@
 
 #include "r6rs-lib-unicode.h"
 
+#include <vector>
+
 enum category_ids {
   Lu,
   Ll,
@@ -59,22 +61,22 @@ SchemeObject *s_char_general_category(Scheme *scheme, SchemeObject *c) {
 
 SchemeObject *s_string_downcase(Scheme *scheme, SchemeObject *s) {
   assert_arg_string_type(L"string-downcase", 1, s);
-  wchar_t result[s->length + 1];
+  std::vector<wchar_t> result(s->length + 1);
   result[s->length] = 0;
   for (uint32_t i = 0; i < s->length; i++) {
     result[i] = tolower(s->str[i]);
   }
-  return SchemeObject::createString(result);
+  return SchemeObject::createString(result.data());
 }
 
 SchemeObject *s_string_upcase(Scheme *scheme, SchemeObject *s) {
   assert_arg_string_type(L"string-downcase", 1, s);
-  wchar_t result[s->length + 1];
+  std::vector<wchar_t> result(s->length + 1);
   result[s->length] = 0;
   for (uint32_t i = 0; i < s->length; i++) {
     result[i] = toupper(s->str[i]);
   }
-  return SchemeObject::createString(result);
+  return SchemeObject::createString(result.data());
 }
 
 void R6RSLibUnicode::bind(Scheme *scheme, SchemeObject *envt) {

--- a/src/scheme/scheme.cpp
+++ b/src/scheme/scheme.cpp
@@ -14,6 +14,7 @@
 #include <iomanip>
 #include <stdexcept>
 #include <unistd.h>
+#include <vector>
 
 #include "compiler.h"
 #include "filenames.h"
@@ -778,7 +779,7 @@ SchemeObject *s_map_internal(Scheme *scheme, const wchar_t *procname, int num,
   SchemeObject *proc = *args;
   assert_arg_procedure_type(procname, 1, proc);
 
-  SchemeObject *cropped_args[num - 1];
+  std::vector<SchemeObject *> cropped_args(num - 1);
 
   for (int i = 1; i < num; i++) {
     assert_non_atom_type(procname, i, args[i]);

--- a/src/ttf.cpp
+++ b/src/ttf.cpp
@@ -3,6 +3,7 @@
 #include "exception.h"
 #include <cassert>
 #include <iomanip>
+#include <vector>
 
 #define ids2kernkey(l, r) (((l) << 16) | (r))
 
@@ -326,9 +327,9 @@ void TrueTypeFont::read_cmap_table(uint32_t offset) {
   read_struct("ss", (char *)&index, sizeof(CmapIndex));
   //    cout << "cmap subtables " << index.numberSubtables << endl;
 
-  uint32_t offsets[index.numberSubtables];
-  uint16_t platformIDs[index.numberSubtables];
-  uint16_t platformSpecificIDs[index.numberSubtables];
+  std::vector<uint32_t> offsets(index.numberSubtables);
+  std::vector<uint16_t> platformIDs(index.numberSubtables);
+  std::vector<uint16_t> platformSpecificIDs(index.numberSubtables);
 
   for (int i = 0; i < index.numberSubtables; i++) {
     read_struct("ssi", (char *)&encSubTable, sizeof(CmapEncodingSubtable));
@@ -400,7 +401,7 @@ void TrueTypeFont::read_gsub_table(uint32_t offset) { is->seekg(offset); }
 
 void TrueTypeFont::processSimpleGlyph(TrueTypeFont::Glyph *glyph,
                                       int16_t numberOfContours) {
-  uint16_t endPtsOfContours[numberOfContours];
+  std::vector<uint16_t> endPtsOfContours(numberOfContours);
 
   for (int16_t i = 0; i < numberOfContours; i++) {
     endPtsOfContours[i] = read_uint16();
@@ -414,7 +415,7 @@ void TrueTypeFont::processSimpleGlyph(TrueTypeFont::Glyph *glyph,
   }
 
   // Read RLE-encoded flags
-  uint8_t flags[numberOfPoints];
+  std::vector<uint8_t> flags(numberOfPoints);
   for (int16_t i = 0; i < numberOfPoints; i++) {
     uint8_t flag = read_uint8();
     if ((flag & 0xc0) != 0)
@@ -430,8 +431,8 @@ void TrueTypeFont::processSimpleGlyph(TrueTypeFont::Glyph *glyph,
   }
 
   // Read coordinates
-  int16_t xCoordinates[numberOfPoints];
-  int16_t yCoordinates[numberOfPoints];
+  std::vector<int16_t> xCoordinates(numberOfPoints);
+  std::vector<int16_t> yCoordinates(numberOfPoints);
 
   int16_t xCoord = 0;
   for (uint16_t i = 0; i < numberOfPoints; i++) {

--- a/test/testthreads.cpp
+++ b/test/testthreads.cpp
@@ -12,6 +12,7 @@ extern "C" {
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
+#include <vector>
 
 using namespace std;
 
@@ -34,8 +35,8 @@ void *threadDo(void *input) {
 void test_threads() {
   int threads_num = 10;
 
-  pthread_t threads[threads_num];
-  threadargs myargs[threads_num]; // arguments for threadDo
+  vector<pthread_t> threads(threads_num);
+  vector<threadargs> myargs(threads_num); // arguments for threadDo
 
   for (int i = 0; i < threads_num; i++) {
     myargs[i].a = i;


### PR DESCRIPTION
## Summary
- replace C++ variable length arrays with standard containers or fixed-size arrays
- keep raw pointer APIs unchanged by passing vector data where needed
- avoid extra copies in Polynomial operations by filling result storage directly

Fixes #9.

## Verification
- make clean
- make check
- Benchmark: rendered scenes/isosurface.scm with -j 1 on this branch and origin/master
  - this branch: Renderer/Wall time 03:06.82, /usr/bin/time real 186.85s
  - origin/master: Renderer/Wall time 03:10.47, /usr/bin/time real 191.28s
  - output files had identical SHA1: 7a9dfcd2a7f2830772e21460edaf1da2c332f680

Note: local builds still print the existing libtool and -bind_at_load warnings from the current base; this PR does not touch that.