### PR TITLE
Fix benchmark scene path factories

### DIFF
--- a/scenes/lib/paths.scm
+++ b/scenes/lib/paths.scm
@@ -67,7 +67,8 @@
    #f)))
 
 (define (make-circle center radius normal)
- (let* ((a (if (v= normal y-axis vector-epsilon) y-axis x-axis))
+ (let* ((x-up (vcrossproduct x-axis normal))
+        (a (if (< (vlength x-up) vector-epsilon) y-axis x-axis))
         (o (orient identity-matrix
 		       normal (vcrossproduct a normal)))
         (m (translate o center)))
@@ -122,7 +123,6 @@
 (define (make-bezier-spline . vector) 'todo)
 
 (define (make-catmullrom-spline . vector) 'todo)
-
 
 
 

--- a/scenes/lib/raygay.scm
+++ b/scenes/lib/raygay.scm
@@ -2,7 +2,6 @@
 (load "records-procedural.scm")
 
 (load "vector-math.scm")
-(load "paths.scm")
 (load "handy-extensions.scm")
 (load "image-sizes.scm")
 (load "mesh.scm")


### PR DESCRIPTION
## Summary
- Stop loading the old Scheme path factory definitions from raygay.scm, so normal scenes use the native C++ PathFactory bindings expected by make-extrusion.
- Keep the old paths.scm helpers working when loaded directly by making make-circle choose a non-parallel helper axis.

Fixes #17.

## Verification
- make check
- cd scenes && /usr/bin/time -p ../src/raygay -j 1 benchmarkscene.scm /private/tmp/raygay-benchmarkscene.tga
  - completed successfully; Renderer/Wall time: 00:02.33; Kd-tree/Objects: 2424