### PR TITLE
Fix native path tangent binding

### DIFF
--- a/src/parser/pathfactory.cpp
+++ b/src/parser/pathfactory.cpp
@@ -140,5 +140,5 @@ void PathFactory::register_procs(Scheme *scheme) {
   scheme->assign(L"point-on-path", 2, 0, 0,
                  (SchemeObject * (*)()) PathFactory::point_on_path);
   scheme->assign(L"tangent-to-path", 2, 0, 0,
-                 (SchemeObject * (*)()) PathFactory::point_on_path);
+                 (SchemeObject * (*)()) PathFactory::tangent_to_path);
 }

--- a/test/scheme/test-native-paths.scm
+++ b/test/scheme/test-native-paths.scm
@@ -1,0 +1,8 @@
+(define (test-native-circle-path)
+ ; This exercises the native C++ PathFactory binding before paths.scm
+ ; replaces make-circle/point-on-path/tangent-to-path with Scheme versions.
+ (define c (make-circle #(0 0 0) 10 #(0 1 0)))
+ (test "point" (near-equal? (point-on-path c 0.0) #(-10 0 0)))
+ (test "tangent" (near-equal? (tangent-to-path c 0.0) #(0 0 1))))
+
+(run-test "Native circle path" test-native-circle-path)

--- a/test/scheme/tests.scm
+++ b/test/scheme/tests.scm
@@ -1,5 +1,6 @@
 (load "scheme/test-objects.scm")
 (load "scheme/test-format.scm")
+(load "scheme/test-native-paths.scm")
 (load "scheme/test-paths.scm")
 (load "scheme/test-vector-math.scm")
 (load "scheme/test-r6rs-lib-bytevectors.scm")


### PR DESCRIPTION
## Summary
- Register tangent-to-path with PathFactory::tangent_to_path instead of point_on_path.
- Add a native path regression test that runs before paths.scm replaces the native bindings with Scheme implementations.

## Verification
- cd test && ./testparser
- make check