### PR TITLE
Improve apply argument errors

### DIFF
--- a/src/scheme/interpreter.cpp
+++ b/src/scheme/interpreter.cpp
@@ -437,8 +437,9 @@ fn_ptr eval_apply(Interpreter::State *state) {
   while (args != S_EMPTY_LIST) {
     i++;
     SchemeObject *arg = s_car(scheme, args);
-    if (i_pair_p(arg) == S_TRUE || arg == S_EMPTY_LIST) {
-      if (s_cdr(scheme, args) == S_EMPTY_LIST) {
+    bool is_last_arg = s_cdr(scheme, args) == S_EMPTY_LIST;
+    if (is_last_arg) {
+      if (i_pair_p(arg) == S_TRUE || arg == S_EMPTY_LIST) {
         // arg is a list and last argument
         if (collected == S_EMPTY_LIST) {
           collected = arg;
@@ -446,7 +447,14 @@ fn_ptr eval_apply(Interpreter::State *state) {
           i_set_cdr_e(prev, arg);
         }
       } else {
-        throw scheme_exception(L"Illegal argument");
+        if (collected != S_EMPTY_LIST) {
+          state->stack.pop_back();
+        }
+        state->stack.pop_back();
+        wostringstream ss;
+        ss << L"Wrong argument-type (expecting list) in position " << i + 1;
+        ss << L" in call to apply: " << arg->toString();
+        throw scheme_exception(ss.str());
       }
     } else {
       if (collected == S_EMPTY_LIST) {

--- a/src/scheme/scheme.cpp
+++ b/src/scheme/scheme.cpp
@@ -430,7 +430,11 @@ Scheme::Scheme(int argc, char *argv[]) {
 
   try {
     eval(L"(define-macro (values . x) `(list ,@x))", scheme_report_environment);
-    eval(L"(define-macro (call-with-values f g)  `(apply ,g (,f)))",
+    eval(L"(define-macro (call-with-values f g)"
+         L"  `(let ((vals (,f)))"
+         L"     (if (list? vals)"
+         L"       (apply ,g vals)"
+         L"       (,g vals))))",
          scheme_report_environment);
     // TODO: Memoize the result of delayed value.
     // R6RS has a definition for delay that does just that - but uses
@@ -745,8 +749,8 @@ SchemeObject *s_apply(Scheme *scheme, int num, SchemeStack::iterator args) {
 
   for (int i = 0; i < num; i++) {
     SchemeObject *arg = *args++;
-    if (i_pair_p(arg) == S_TRUE || arg == S_EMPTY_LIST) {
-      if (i == num - 1) {
+    if (i == num - 1) {
+      if (i_pair_p(arg) == S_TRUE || arg == S_EMPTY_LIST) {
         // arg is a list and last argument
         if (collected == S_EMPTY_LIST) {
           collected = arg;
@@ -754,7 +758,11 @@ SchemeObject *s_apply(Scheme *scheme, int num, SchemeStack::iterator args) {
           i_set_cdr_e(prev, arg);
         }
       } else {
-        throw scheme_exception(L"Illegal argument");
+        state->stack.pop_back();
+        wostringstream ss;
+        ss << L"Wrong argument-type (expecting list) in position " << i + 2;
+        ss << L" in call to apply: " << arg->toString();
+        throw scheme_exception(ss.str());
       }
     } else {
       if (collected == S_EMPTY_LIST) {

--- a/src/scheme/testscheme.cpp
+++ b/src/scheme/testscheme.cpp
@@ -314,9 +314,13 @@ void test_interpreter() {
   assert_eval(s, L"(apply + (list 3 4))", L"7");
   assert_eval(s, L"(apply + '(1 2 3))", L"6");
   assert_eval(s, L"(apply + 1 2 '(3 4))", L"10");
+  assert_eval(s, L"(apply list '(1 2) '(3 4))", L"((1 2) 3 4)");
   assert_eval(s, L"(apply list '())", L"()");
   assert_eval(s, L"(apply * 1 2 (list 3 4))", L"24");
   assert_eval(s, L"(apply apply `(,+ ,(list 1 2)))", L"3");
+  assert_eval(s, L"(apply list '(1 2) 3 '())", L"((1 2) 3)");
+  assert_eval(s, L"(apply list 1 '(2) '())", L"(1 (2))");
+  assert_fail(s, L"(apply + 1 2 3)");
   // assert_fail(s, L"(apply define (string->symbol \"xx\") 10)");
   s->eval(L"(define compose (lambda (f g) (lambda args (f (apply g args)))))");
   assert_eval(s, L"((compose sqrt *) 12 75)", L"30.0"); // R^5RS, Section 6.4.


### PR DESCRIPTION
## Summary
- Make apply handling match the Scheme/R7RS rule: call proc with the elements of (append (list arg1 ...) args).
- Allow list values as ordinary non-final apply arguments.
- Require the final apply argument to be a list, using the existing argument counter for a precise error message.
- Adjust the local call-with-values macro so single non-list producer results do not rely on non-standard apply behavior.
- Add regression coverage for non-final list arguments and non-list final arguments.

Part of #23.

## Verification
- src/scheme/testscheme
- make check