### PR TITLE
Fix legacy Scheme scene compatibility

### DIFF
--- a/scenes/demo-steps.scm
+++ b/scenes/demo-steps.scm
@@ -2,60 +2,60 @@
 (load "lib/raygay.scm")
 
 (set-image-size '(1024 768))
-(set-background '(0.3 0.6 0.7))
+(set-background #(0.3 0.6 0.7))
 
 (set-renderer "raytracer")
 (set-camera 
   (make-pinhole-camera 
-    '( pos (2 17 20)
-       lookat (0 0 0)
-       up (0 1 0)
+    '( pos #(2 17 20)
+       lookat #(0 0 0)
+       up #(0 1 0)
        fov 45
        aa 2)))
 
 (define chrome
   (make-material
-    '( diffuse (0.9 0.9 0.9)
+    '( diffuse #(0.9 0.9 0.9)
        kd 0.4
-       specular (1.0 1.0 1.0)
+       specular #(1.0 1.0 1.0)
        ks 0.6
        specpow 45)))
 
 
 
-(add-to-scene (make-pointlight '(-500 1300 1300)))
+(add-to-scene (make-pointlight #(-500 1300 1300)))
 
 (define materials
   (list 
      (make-material
-       '( diffuse (0.6 0.8 0.9)
+       '( diffuse #(0.6 0.8 0.9)
           kd 1.0
           ks 0.0
           specpow 45))
       (make-material
-        '( diffuse (0.6 0.9 0.8)
+        '( diffuse #(0.6 0.9 0.8)
            kd 1.0
            ks 0.0
            specpow 45))
        (make-material
-         '( diffuse (0.6 0.9 0.99)
+         '( diffuse #(0.6 0.9 0.99)
             kd 0.8
-            specular (1.0 1.0 1.0)
+            specular #(1.0 1.0 1.0)
             ks 0.2
             specpow 45))
-))          
-                
+))
+
 (define (make-jittered-box x z)
 (translate
   (rotate-z
     (rotate-x
       (rotate-y        
-        (make-rounded-box '(-0.5 -0.2 -0.5) '(0.5 0.2 0.5) 0.1 (pick-random-from-list materials))        
+        (make-rounded-box #(-0.5 -0.2 -0.5) #(0.5 0.2 0.5) 0.1 (pick-random-from-list materials))
         (random2 -10 10))
       (random2 -5 5))
     (random2 -5 5))
-  (list x 0 z)))
-                                                 
+  (vector x 0 z)))
+
 (do ((x -5 (+ 1 x)))
   ((= x 5))
     (do ((z -5 (+ 1 z)))

--- a/scenes/l-sys-demo.scm
+++ b/scenes/l-sys-demo.scm
@@ -3,45 +3,45 @@
 (load "lib/l-system.scm")
 
 (set-image-size '(640 480))
-(set-background '(0.3 0.6 0.7))
+(set-background #(0.3 0.6 0.7))
 
 (set-renderer "raytracer")
 (set-camera 
   (make-pinhole-camera 
-    '( pos (1000 1000 2000)
-       lookat (0 500 0)
-       up (0 1 0)
+    '( pos #(1000 1000 2000)
+       lookat #(0 500 0)
+       up #(0 1 0)
        fov 45
        aa 0)))
 
 (define brown
   (make-material
-    '( diffuse (0.7 0.4 0.2)
+    '( diffuse #(0.7 0.4 0.2)
        kd 1.0
        ks 0.0)))
 
 (define green
   (make-material
-    '( diffuse (0.4 0.7 0.2)
+    '( diffuse #(0.4 0.7 0.2)
        kd 1.0
        ks 0.0)))
 
 (define chrome
   (make-material
-    '( diffuse (0.8 0.8 0.8)
+    '( diffuse #(0.8 0.8 0.8)
        kd 0.2
-       specular (1.0 1.0 1.0)
+       specular #(1.0 1.0 1.0)
        ks 0.8
        specpow 30)))
 
 
-(add-to-scene (make-pointlight '(500 1300 1300)))
-(add-to-scene (make-pointlight '(-500 1300 1300)))
+(add-to-scene (make-pointlight #(500 1300 1300)))
+(add-to-scene (make-pointlight #(-500 1300 1300)))
 
 (add-to-scene
-    (make-box 
-      '(-11700 -51 -11700) 
-      '(11700 1 11700) 
+    (make-box
+      #(-11700 -51 -11700)
+      #(11700 1 11700)
       green))
 
 
@@ -62,4 +62,3 @@
   rules
   5   ; depth
   brown))
-

--- a/scenes/lib/genetics.scm
+++ b/scenes/lib/genetics.scm
@@ -12,13 +12,13 @@
   (do ((i 0 (+ i 1)))
     ((= i (length l)) l)
     (if (< (random2 0 100) percent)
-       (list-swap l i (random (length l))))))
+       (list-swap l i (random-index (length l))))))
 
 ; Do a genetic crossover from two parent chromosomes.
 ; One-point crossover technique.
 (define (crossover c1 c2)
    (let loop ((filler c2)
-              (result (reverse (list-head c1 (random (length c1))))))
+              (result (reverse (list-head c1 (random-index (length c1))))))
      (if (null? filler)
        (reverse result)
        (if (member (car filler) result)
@@ -28,7 +28,7 @@
 ; Randomize list
 (define (list-shuffle l)
   (dotimes i (length l)
-    (list-swap l i (random (length l))))
+    (list-swap l i (random-index (length l))))
   l)
 
 ; Randomized list of 0,1,...,n
@@ -49,7 +49,7 @@
 
 (define (pick-chromosome population dist-table)
   (list-ref population 
-   (list-ref dist-table (random (length dist-table)))))
+   (list-ref dist-table (random-index (length dist-table)))))
 
 ; For pop-size 4 this results in (0 0 0 0 1 1 1 2 2 3)
 (define (precalc-dist-table pop-size)

--- a/scenes/lib/handy-extensions.scm
+++ b/scenes/lib/handy-extensions.scm
@@ -7,6 +7,12 @@
 (define 2π (* 2.0 π))
 (define π/2 (/ π 2.0))
 
+(define (random2 min max)
+  (random min max))
+
+(define (random-index upper)
+  (truncate (random 0 upper)))
+
 (define (first vec) (car vec))
 (define (second vec) (cadr vec))
 (define (third vec) (caddr vec))
@@ -42,7 +48,7 @@
 
 (define (pick-random-from-list l)
   "Returns a random element from a list"        
-  (list-ref l (random (length l))))
+  (list-ref l (random-index (length l))))
 
 (define (sum . l)
  "Sums of a list of numbers"
@@ -119,4 +125,3 @@
 ;(define ￮ make-sphere)
 ;(define □ make-box)
 ;(define ■ make-solid-box)
-

--- a/scenes/necklace.scm
+++ b/scenes/necklace.scm
@@ -1,56 +1,54 @@
 
-(load "globals.scm")
-(load "objects.scm")
 (load "lib/raygay.scm")
 
 (set-image-size '(640 480))
-(set-background '(0.3 0.6 0.7))
+(set-background #(0.3 0.6 0.7))
 
 (set-renderer "raytracer")
 (set-camera 
   (make-pinhole-camera 
-    '( "pos" (1000 1000 2000)
-       "lookat" (0 100 0)
-       "up" (0 1 0)
-       "fov" 45
-       "aa" 4)))
+    '( pos #(1000 1000 2000)
+       lookat #(0 100 0)
+       up #(0 1 0)
+       fov 45
+       aa 4)))
 
 (define brown
   (make-material
-    '( "diffuse" (0.7 0.4 0.2)
-       "kd" 1.0
-       "ks" 0.0)))
+    '( diffuse #(0.7 0.4 0.2)
+       kd 1.0
+       ks 0.0)))
 
 (define grey85
   (make-material
-    '( "diffuse" (0.85 0.85 0.85)
-       "kd" 1.0
-       "ks" 0.0)))
+    '( diffuse #(0.85 0.85 0.85)
+       kd 1.0
+       ks 0.0)))
 
 (define chrome
   (make-material
-    '( "diffuse" (0.8 0.8 0.8)
-       "kd" 0.2
-       "specular" (1.0 1.0 1.0)
-       "ks" 0.8
-       "specpow" 30)))
+    '( diffuse #(0.8 0.8 0.8)
+       kd 0.2
+       specular #(1.0 1.0 1.0)
+       ks 0.8
+       specpow 30)))
 
 
-(add-to-scene (make-pointlight '(500 1300 1300)))
-(add-to-scene (make-pointlight '(-500 1500 1300)))
+(add-to-scene (make-pointlight #(500 1300 1300)))
+(add-to-scene (make-pointlight #(-500 1500 1300)))
 
 (add-to-scene
-    (make-box 
-      '(-1700 -51 -1700) 
-      '(1700 1 1700) 
+    (make-box
+      #(-1700 -51 -1700)
+      #(1700 1 1700)
       brown))
 
 (define spiral
  (make-spiral
-  (make-circle '(0 200 0) 300 '(0 1 0))
+  (make-circle #(0 200 0) 300 #(0 1 0))
   100
   5 0.0))
 
 (add-to-scene
  (make-necklace spiral 200 
-  (lambda () (make-sphere '(0 0 0) 20 chrome))))
+  (lambda () (make-sphere #(0 0 0) 20 chrome))))

--- a/scenes/test.scm
+++ b/scenes/test.scm
@@ -1,18 +1,18 @@
 
-(load "globals.scm")
+(load "lib/raygay.scm")
 (load "lib/objects/make-rounded-cylinder.scm")
 
-(set! image-size '(1600 1200))
+(set-image-size '(1600 1200))
 ;(set! background (make-texture "gfx/goodmorning.jpg" 1 1 'bilinear))
 ;(set! background (make-texture "gfx/alltrans.png" 1 1 'none))
-(set! background '(0.337 0.417 0.527))
+(set-background #(0.337 0.417 0.527))
 
-(set! renderer "raytracer")
-(set! camera 
-  (make-pinhole-camera 
-    '( pos (2 10 20)
-       lookat (0 2.5 0)
-       up (0 1 0)
+(set-renderer "raytracer")
+(set-camera
+  (make-pinhole-camera
+    '( pos #(2 10 20)
+       lookat #(0 2.5 0)
+       up #(0 1 0)
        fov 45
        aa 4)))
 
@@ -27,17 +27,16 @@
 
 (define chrome
   (make-material
-    (list 'diffuse '(1.0 1.0 1.0)
+    (list 'diffuse #(1.0 1.0 1.0)
 	  'kd 0.8
-	  'specular '(1.0 1.0 1.0)
+	  'specular #(1.0 1.0 1.0)
 	  'ks 0.2
        'specpow 35
        ;'normal perturb-noise 
        )))
 
 
-(set! scene (list (make-pointlight '(300 1300 1300))))
+(add-to-scene (make-pointlight #(300 1300 1300)))
 
-(append!
-  scene
+(add-to-scene
    (make-rounded-cylinder 7 5 0.05 chrome))

--- a/scenes/twister.scm
+++ b/scenes/twister.scm
@@ -9,34 +9,34 @@
 (set-renderer "raytracer")
 (set-camera 
   (make-pinhole-camera 
-    '( pos (-2000 2000 30)
-       lookat (0 200 0)
-       up (0 1 0)
+    '( pos #(-2000 2000 30)
+       lookat #(0 200 0)
+       up #(0 1 0)
        fov 35
        aa 4)))
 
 (define brown
   (make-material
-    '( diffuse (0.7 0.4 0.2)
+    '( diffuse #(0.7 0.4 0.2)
        kd 1.0
        ks 0.0)))
 
 (define grey85
   (make-material
-    '( diffuse (0.85 0.85 0.85)
+    '( diffuse #(0.85 0.85 0.85)
        kd 1.0
        ks 0.0)))
 
 (define chrome
   (make-material
-    '( diffuse (0.8 0.8 0.8)
+    '( diffuse #(0.8 0.8 0.8)
        kd 0.2
-       specular (1.0 1.0 1.0)
+       specular #(1.0 1.0 1.0)
        ks 0.8
        specpow 30)))
 
 
-(add-to-scene (make-pointlight '(500 1300 1300)))
+(add-to-scene (make-pointlight #(500 1300 1300)))
 ;(append! scene (list (make-pointlight '(-500 1500 1300))))
 
 ;(append!
@@ -52,7 +52,6 @@
 
 (add-to-scene    
   (make-extrusion 
-   (make-circle '(0 300 0) 400 '(0 1 0))
-   (make-ellipse '(0 0 0) 100 200 '(0 0 1))
+   (make-circle #(0 300 0) 400 #(0 1 0))
+   (make-ellipse #(0 0 0) 100 200 #(0 0 1))
    5 100 500 chrome))
-

--- a/scenes/webdisk-icon.scm
+++ b/scenes/webdisk-icon.scm
@@ -5,42 +5,42 @@
 (set-image-size '(96 96))
 (set-image-size '(2048 2048))
 (set-image-size '(256 256))
-(set-background '(0.3 0.6 0.7 0.0))
+(set-background #(0.3 0.6 0.7 0.0))
 
 (set-renderer "raytracer")
 (set-camera 
   (make-pinhole-camera 
-    '( pos (200 1400 2000)
-       lookat (0 0 0)
-       up (0 1 0)
+    '( pos #(200 1400 2000)
+       lookat #(0 0 0)
+       up #(0 1 0)
        fov 27 
        aa 1)))
 
 (define brown
   (make-material
-    '( diffuse (0.7 0.4 0.2)
+    '( diffuse #(0.7 0.4 0.2)
        kd 1.0
        ks 0.0)))
 
 (define green
   (make-material
 ;     (list 'diffuse earth
-    (list 'diffuse '(0.1 0.4 0.5)
+    (list 'diffuse #(0.1 0.4 0.5)
        'kd 0.9
        'ks 0.0)))
 
 (define chrome
   (make-material
-    '( diffuse (0.8 0.8 0.8)
+    '( diffuse #(0.8 0.8 0.8)
        kd 0.2
-       specular (1.0 1.0 1.0)
+       specular #(1.0 1.0 1.0)
        ks 0.8
        specpow 30)))
 
 
 (add-to-scene (list
-  (make-pointlight '(500 1300 1300))
-  (make-pointlight '(-500 1300 1300))))
+  (make-pointlight #(500 1300 1300))
+  (make-pointlight #(-500 1300 1300))))
 
 ;(add-to-scene
 ;    (make-box 
@@ -60,8 +60,8 @@
       (rotate
 	(rotate
 	  (make-torus R r brown)
-	  '(1 0 0 ) 90)
-	'(0 1 0) (* i (/ 180 longitudes))))
+	  #(1 0 0) 90)
+	#(0 1 0) (* i (/ 180 longitudes))))
     (loop (+ i 1)))))
 
 (let loop ((i (- 1 lattitudes)))
@@ -74,9 +74,8 @@
       (add-to-scene
 	(translate 
 	  (make-torus RR r brown)
-	  (list 0 h 0)))
+	  (vector 0 h 0)))
       (loop (+ i 1)))))
 
 (add-to-scene
- (make-sphere '(0 0 0) (- R (* 4 r)) green))
-
+ (make-sphere #(0 0 0) (- R (* 4 r)) green))

--- a/scenes/wire-globe.scm
+++ b/scenes/wire-globe.scm
@@ -3,20 +3,20 @@
 
 (set-image-size '(96 96))
 (set-image-size '(800 800))
-(set-background '(0.3 0.6 0.7 0.0))
+(set-background #(0.3 0.6 0.7 0.0))
 
 (set-renderer "raytracer")
 (set-camera 
   (make-pinhole-camera 
-    '( pos (200 1400 2000)
-       lookat (0 0 0)
-       up (0 1 0)
+    '( pos #(200 1400 2000)
+       lookat #(0 0 0)
+       up #(0 1 0)
        fov 27 
        aa 0)))
 
 (define brown
   (make-material
-    '( diffuse (0.7 0.4 0.2)
+    '( diffuse #(0.7 0.4 0.2)
        kd 1.0
        ks 0.0)))
 
@@ -32,9 +32,9 @@
 
 (define glass
   (make-material
-    '( diffuse (0.8 0.8 0.8)
+    '( diffuse #(0.8 0.8 0.8)
        kd 0.0
-       specular (1.0 1.0 1.0)
+       specular #(1.0 1.0 1.0)
        ks 0.3
        kt 0.7
        eta 1.33
@@ -42,8 +42,8 @@
 
 
 (add-to-scene (list
-  (make-pointlight '(500 1300 1300))
-  (make-pointlight '(-500 1300 1300))))
+  (make-pointlight #(500 1300 1300))
+  (make-pointlight #(-500 1300 1300))))
 
 (define longitudes 10)
 (define lattitudes 8)
@@ -53,12 +53,12 @@
 (let loop ((i 0))
   (if (< i longitudes)
    (begin
-    (add-to-scene
-      (rotate
-	(rotate
-	  (make-torus R r brown)
-	  '(1 0 0 ) 90)
-	'(0 1 0) (* i (/ 180 longitudes))))
+	    (add-to-scene
+	      (rotate
+		(rotate
+		  (make-torus R r brown)
+		  #(1 0 0) 90)
+		#(0 1 0) (* i (/ 180 longitudes))))
     (loop (+ i 1)))))
 
 (let loop ((i (- 1 lattitudes)))
@@ -66,9 +66,8 @@
     (let* ((a (* π (/ i (* 2 lattitudes))))
 	   (RR (* R (cos a)))
 	   (h  (* R (sin a))))
-      (add-to-scene
-	(translate 
-	  (make-torus RR r brown)
-	  (list 0 h 0)))
+	      (add-to-scene
+		(translate
+		  (make-torus RR r brown)
+		  (vector 0 h 0)))
       (loop (+ i 1)))))
-


### PR DESCRIPTION
## Summary
- migrate easy legacy Scheme scenes from list/string-key options to current symbol-key/vector APIs
- add Scheme compatibility helpers for random2 and random list indexes
- update genetics helper code to avoid the old one-argument random form

## Follow-up issues
- #25 Restore or migrate legacy .gay scene format
- #26 Fix l-system scene library parsing
- #27 Restore missing assets referenced by scenes

## Verification
- make check
- src/scheme/testscheme
- smoke rendered with ../src/raygay -f -j 1: twister.scm, necklace.scm, test.scm, demo-steps.scm, webdisk-icon.scm, benchmark-kdtree.scm, sampling-methods.scm, heart.scm

Known remaining scene blockers are tracked in the follow-up issues above.