### PR TITLE
Replace deprecated MD5 sprintf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,6 +391,11 @@ if(BUILD_TESTING)
     set_tests_properties(${test_name} PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
   endforeach()
 
+  add_executable(testhttp test/testhttp.cpp)
+  target_include_directories(testhttp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/test)
+  target_link_libraries(testhttp PRIVATE raygay_http)
+  add_test(NAME testhttp COMMAND testhttp)
+
   add_executable(testspeed test/testspeed.cpp)
   target_include_directories(testspeed PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/test)
   target_link_libraries(testspeed PRIVATE raygay_tracer)

--- a/src/http/httpcommon.cpp
+++ b/src/http/httpcommon.cpp
@@ -1,9 +1,7 @@
 
 #include "http/httpcommon.h"
 
-extern "C" {
 #include "http/md5.h"
-}
 #include "exception.h"
 #include "math/constants.h" // For MIN()
 #include <cstring>

--- a/src/http/httpserver.cpp
+++ b/src/http/httpserver.cpp
@@ -12,8 +12,9 @@
 #include <iostream>
 #include <sstream>
 
-extern "C" {
 #include "http/md5.h"
+
+extern "C" {
 #include <arpa/inet.h> /*  inet (3) funtions         */
 #include <sys/socket.h>
 #include <sys/stat.h>

--- a/src/http/md5.c
+++ b/src/http/md5.c
@@ -137,7 +137,7 @@ md5_stream_hex (FILE *stream, char *resblock)
     unsigned int i;
     md5_stream(stream, res);
     for(i = 0; i < 16; i++, resblock += 2) {
-        sprintf(resblock, "%02x", (unsigned char) res[i]);
+        snprintf(resblock, 3, "%02x", (unsigned char) res[i]);
     }
 }
 

--- a/src/http/md5.h
+++ b/src/http/md5.h
@@ -100,6 +100,10 @@ struct md5_ctx {
   char buffer[128] __attribute__((__aligned__(__alignof__(md5_uint32))));
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * The following three functions are build up the low level used in
  * the functions `md5_stream' and `md5_buffer'.
@@ -155,5 +159,9 @@ extern void md5_stream_hex __P((FILE * stream, char *resblock));
    output yields to the wanted ASCII representation of the message
    digest.  */
 extern void *md5_buffer __P((const char *buffer, size_t len, void *resblock));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* md5.h */

--- a/test/testhttp.cpp
+++ b/test/testhttp.cpp
@@ -1,0 +1,27 @@
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "http/md5.h"
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+
+bool test_md5_stream_hex() {
+  FILE *input = tmpfile();
+  if (input == NULL) {
+    return false;
+  }
+
+  char md5_hex[34];
+  memset(md5_hex, 'X', sizeof(md5_hex));
+  md5_stream_hex(input, md5_hex);
+  fclose(input);
+
+  return strcmp(md5_hex, "d41d8cd98f00b204e9800998ecf8427e") == 0 &&
+         strlen(md5_hex) == 32 && md5_hex[32] == '\0' && md5_hex[33] == 'X';
+}
+
+int main(int argc, char *argv[]) {
+  return test_md5_stream_hex() ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
- replace the MD5 hex formatter's deprecated sprintf call with snprintf
- make md5.h safe to include directly from C++ by declaring the MD5 API with C linkage
- add a CTest-covered HTTP/MD5 test that verifies 32 hex chars plus terminator without overwriting the next byte

Fixes #22.

## Tested
- cmake --build build
- ctest --test-dir build --output-on-failure -R testhttp
- ctest --test-dir build --output-on-failure