### PR TITLE
Add dedicated bigint test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,6 +374,10 @@ if(BUILD_TESTING)
   target_link_libraries(testrational PRIVATE raygay_scheme)
   add_test(NAME testrational COMMAND testrational)
 
+  add_executable(testbigint src/scheme/testbigint.cpp)
+  target_link_libraries(testbigint PRIVATE raygay_scheme)
+  add_test(NAME testbigint COMMAND testbigint)
+
   foreach(test_name IN ITEMS
     testobjects
     testimage

--- a/src/scheme/Makefile.am
+++ b/src/scheme/Makefile.am
@@ -28,10 +28,11 @@ libscheme_la_SOURCES = lexer.h lexer.cpp \
 # -----------------------------------------------------
 # Tests
 # -----------------------------------------------------
-check_PROGRAMS = testscheme testrational
+check_PROGRAMS = testscheme testrational testbigint
 testscheme_SOURCES = testscheme.cpp
 testscheme_LDADD = libscheme.la
 testrational_SOURCES = testrational.cpp
-TESTS = testscheme testrational
+testbigint_SOURCES = testbigint.cpp
+testbigint_LDADD = libscheme.la
+TESTS = testscheme testrational testbigint
  
-

--- a/src/scheme/bigint.cpp
+++ b/src/scheme/bigint.cpp
@@ -85,6 +85,9 @@ string bigint::toString(uint32_t radix) const {
   char chars[37] = "0123456789abcdefghijklmnopqrstuvwxyz";
   if (radix >= 37 || radix == 0)
     throw invalid_argument("Invalid radix");
+  if (is_zero()) {
+    return "0";
+  }
   bigint b = abs(*this);
   string s = "";
   while (!b.is_zero()) {
@@ -194,6 +197,7 @@ bigint bigint::operator-(int32_t n) const {
 bigint bigint::operator-() const {
   bigint r = *this;
   r.sign = -r.sign;
+  r.normalize();
   return r;
 }
 
@@ -285,11 +289,17 @@ bigint bigint::operator/(int32_t n) const {
 // 257-258. Knuths algo in C:
 // http://www.ddj.com/showArticle.jhtml?documentID=cuj9611breitz&pgno=8
 bigint bigint::operator/(const bigint &denom) const {
+  if (denom.is_zero())
+    throw range_error("Division by zero");
+
   bigint q = 1;
   q.sign = this->sign * denom.sign;
 
   if (abs(*this) < abs(denom))
     return bigint(0);
+
+  if (abs(*this) == abs(denom))
+    return q;
 
   if (denom.exp() == 0) {
     // denom is a long, so send it
@@ -410,16 +420,16 @@ int bigint::compare(const bigint &b1, const bigint &b2) {
   } else if (b1.sign < b2.sign) {
     return -1;
   } else if (b1.digits.size() > b2.digits.size()) {
-    return 1;
+    return b1.sign;
   } else if (b1.digits.size() < b2.digits.size()) {
-    return -1;
+    return -b1.sign;
   } else {
     // Same number of digits and same sign. Compare digits.
     for (int i = b1.digits.size() - 1; i >= 0; i--) {
       if (b1.digits[i] > b2.digits[i]) {
-        return 1;
+        return b1.sign;
       } else if (b1.digits[i] < b2.digits[i]) {
-        return -1;
+        return -b1.sign;
       }
     }
     return 0;
@@ -520,7 +530,8 @@ ostream &operator<<(ostream &os, const bigint &b) {
 
 bigint bigint::times_two() const {
   bigint r = *this;
-  for (uint32_t i = r.size() - 1; i != 0; i--) {
+  uint32_t size = r.size();
+  for (uint32_t i = 0; i < size; i++) {
     r.digits[i] <<= 1;
     if (r.digits[i] >= RADIX) {
       if (i + 1 >= r.size()) {
@@ -566,20 +577,12 @@ bigint bigint::sqrt() const {
     return bigint::ONE;
   }
 
-  // A good initial guess is the square root of the most significant digit times
-  // the square root of its radix part.
-  bigint x_1 = ONE * 100;
-
+  bigint x = TWO.expt((sizeInBits() + 1) / 2);
   while (true) {
-    bigint x_2 = (*this) / x_1;
-    bigint diff = x_2 - x_1;
-    if (diff.is_zero()) {
-      return x_1;
+    bigint next = (x + (*this) / x) / 2;
+    if (next >= x) {
+      return x;
     }
-    if (diff.is_one()) {
-      return x_2;
-    }
-    x_1 = (x_1 + x_2) / 2;
-    // cout << "Guess " << x_1 << endl;
+    x = next;
   }
 }

--- a/src/scheme/testbigint.cpp
+++ b/src/scheme/testbigint.cpp
@@ -1,0 +1,268 @@
+#include "bigint.h"
+#include "testing.h"
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+class construction_test : public Test {
+public:
+  void run() {
+    assertTrue(bigint(123456789) == bigint("123456789"));
+    assertTrue(bigint(-100) == bigint("-100"));
+    assertTrue(bigint("0") == bigint("-0"));
+    assertTrue(bigint("0").is_zero());
+    assertTrue(bigint("-0").is_zero());
+    assertTrue(bigint::ZERO == bigint(0));
+    assertTrue(bigint::ONE == bigint(1));
+    assertTrue(bigint::TWO == bigint(2));
+
+    bigint b1("10");
+    bigint b2 = b1;
+    b1 += 10;
+    assertTrue(b2 == bigint("10"));
+    assertTrue(b1 == bigint("20"));
+  }
+};
+
+class radix_test : public Test {
+public:
+  void run() {
+    assertTrue(bigint("ff", 16) == bigint("255"));
+    assertTrue(bigint("FF", 16) == bigint("255"));
+    assertTrue(bigint("10001", 2) == bigint("17"));
+    assertTrue(bigint("z", 36) == bigint("35"));
+
+    vector<int> radices = {2, 3, 8, 10, 16, 36};
+    vector<string> numbers = {"0",
+                              "1",
+                              "-1",
+                              "123456789123456789123456789",
+                              "-987654321987654321987654321"};
+    for (uint32_t i = 0; i < numbers.size(); i++) {
+      bigint n(numbers[i]);
+      for (uint32_t j = 0; j < radices.size(); j++) {
+        int radix = radices[j];
+        assertTrue(bigint(n.toString(radix), radix) == n);
+      }
+    }
+
+    assertTrue(bigint(0).toString() == "0");
+    assertTrue(bigint(1000).toString() == "1000");
+    assertTrue(bigint(65535).toString(16) == "ffff");
+    assertTrue(bigint(-1000).toString() == "-1000");
+    assertTrue(bigint("123456789123456789").toString() == "123456789123456789");
+
+    bool invalid_radix_failed = false;
+    try {
+      bigint("10", 37);
+    } catch (invalid_argument &) {
+      invalid_radix_failed = true;
+    }
+    assertTrue(invalid_radix_failed);
+
+    bool invalid_digit_failed = false;
+    try {
+      bigint("2", 2);
+    } catch (invalid_argument &) {
+      invalid_digit_failed = true;
+    }
+    assertTrue(invalid_digit_failed);
+  }
+};
+
+class sign_test : public Test {
+public:
+  void run() {
+    assertTrue(-bigint(100) == bigint(-100));
+    assertTrue(-bigint(-100) == bigint(100));
+    assertTrue(-bigint(0) == bigint(0));
+    assertTrue(bigint(-1000) + bigint(1000) == bigint(0));
+    assertTrue(bigint("-1000") + bigint("1000") == bigint("0"));
+    assertTrue(bigint("-1000") - bigint("-1000") == bigint("0"));
+  }
+};
+
+class arithmetic_test : public Test {
+public:
+  void run() {
+    assertTrue(bigint(100) - 20 == bigint(80));
+    assertTrue(bigint(100) - bigint(3) == bigint(97));
+    assertTrue(bigint("3333333333333333333") - bigint("2222222222222222222") ==
+               bigint("1111111111111111111"));
+
+    bigint accumulator("1000000000000000000000000000000");
+    accumulator += bigint("777777777777777777777777777777");
+    accumulator -= bigint("123456789123456789123456789123");
+    assertTrue(accumulator == bigint("1654320988654320988654320988654"));
+
+    assertTrue((bigint(123456789) + 123456789) + 123456789 ==
+               bigint("370370367"));
+    assertTrue(bigint("999999999999999999999999999999999") +
+                   bigint("999999999999999999999999999999999") ==
+               bigint("1999999999999999999999999999999998"));
+    assertTrue(abs(bigint("-111111111111111111")) ==
+               bigint("111111111111111111"));
+
+    assertTrue(bigint(0) * 10 == bigint(0));
+    assertTrue(bigint("1000") * 10 == bigint("10000"));
+    assertTrue(bigint("1000") * -10 == bigint("-10000"));
+    assertTrue(bigint("-1000") * -10 == bigint("10000"));
+    assertTrue(bigint("123456789123456789") * bigint("123456789123456789") ==
+               bigint("15241578780673678515622620750190521"));
+    assertTrue((bigint("123456789") * 123456789) * 123456789 ==
+               bigint("1881676371789154860897069"));
+
+    bigint inplace("123456789123456789");
+    inplace *= 1000;
+    assertTrue(inplace == bigint("123456789123456789000"));
+    assertTrue(bigint(1).times_two() == bigint(2));
+    assertTrue(bigint("1073741824").times_two() == bigint("2147483648"));
+    assertTrue(bigint("123456789").square() == bigint("15241578750190521"));
+  }
+};
+
+class power_test : public Test {
+public:
+  void run() {
+    assertTrue(bigint("100").expt(2) == bigint("10000"));
+    assertTrue(bigint("2").expt(0) == bigint(1));
+    assertTrue(bigint(0).expt(100) == bigint(0));
+    assertTrue(bigint(31).expt(19) == bigint("21670662219970396194714277471"));
+    assertTrue(bigint(17).expt(1000) * bigint(17).expt(500) ==
+               bigint(17).expt(1500));
+    assertTrue(bigint(31).expt(1000) * bigint(31).expt(1500) ==
+               bigint(31).expt(2500));
+  }
+};
+
+class division_test : public Test {
+public:
+  void run() {
+    assertTrue(bigint("9999999999999999999") / 3 ==
+               bigint("3333333333333333333"));
+    assertTrue(bigint(-1000) / 10 == bigint(-100));
+    assertTrue(bigint(1000) / (-10) == bigint(-100));
+    assertTrue(bigint(-1000) / (-10) == bigint(100));
+    assertTrue(bigint(100) / bigint(2) == bigint(50));
+    assertTrue(bigint(100) / bigint(-2) == bigint(-50));
+    assertTrue(bigint(100) / bigint(1000) == bigint(0));
+    assertTrue(bigint(-100) / bigint(1000) == bigint(0));
+    assertTrue(bigint(100) / bigint(-1000) == bigint(0));
+    assertTrue(bigint("123456789123456789") / bigint("123456789123456789") ==
+               bigint(1));
+    assertTrue(bigint("10000000000") / bigint("1000000000") == bigint(10));
+    assertTrue(bigint("10000000000") / bigint("10000000") == bigint(1000));
+    assertTrue(bigint("993850124034") / bigint("1209237") == bigint("821882"));
+    assertTrue(bigint("993850124034") / bigint("821882") == bigint("1209237"));
+    assertTrue(bigint("123456789123456789") / bigint(1) ==
+               bigint("123456789123456789"));
+    assertTrue(bigint("10000000000") / bigint("10") == bigint("1000000000"));
+    assertTrue(bigint("15241578780673678515622620750190521") / bigint("1") ==
+               bigint("15241578780673678515622620750190521"));
+
+    vector<bigint> numerators = {bigint("123456789123456789123456789"),
+                                 bigint("-123456789123456789123456789"),
+                                 bigint("999999999999999999999999999999")};
+    vector<int> denominators = {3, 7, 97, -11};
+    for (uint32_t i = 0; i < numerators.size(); i++) {
+      for (uint32_t j = 0; j < denominators.size(); j++) {
+        bigint n = numerators[i];
+        int d = denominators[j];
+        bigint q = n / d;
+        int r = n % d;
+        assertTrue(q * d + r == n);
+      }
+    }
+
+    assertTrue(bigint(100) % 10 == 0);
+    assertTrue(bigint("10000000000000000000000") % 3 == 1);
+    assertTrue(bigint("-99999999999999999992") % 3 == -2);
+
+    bool divide_by_zero_failed = false;
+    try {
+      bigint(1) / 0;
+    } catch (range_error &) {
+      divide_by_zero_failed = true;
+    }
+    assertTrue(divide_by_zero_failed);
+
+    bool modulo_by_zero_failed = false;
+    try {
+      bigint(1) % 0;
+    } catch (range_error &) {
+      modulo_by_zero_failed = true;
+    }
+    assertTrue(modulo_by_zero_failed);
+  }
+};
+
+class sqrt_test : public Test {
+public:
+  void run() {
+    assertTrue(bigint(0).sqrt() == bigint(0));
+    assertTrue(bigint(1).sqrt() == bigint(1));
+    assertTrue(bigint(2).sqrt() == bigint(1));
+    assertTrue(bigint(99).sqrt() == bigint(9));
+    assertTrue(bigint(100).sqrt() == bigint(10));
+    assertTrue(bigint(10000).sqrt() == bigint(100));
+    assertTrue(bigint("10000000000000000").sqrt() == bigint("100000000"));
+
+    bool negative_sqrt_failed = false;
+    try {
+      bigint(-1).sqrt();
+    } catch (range_error &) {
+      negative_sqrt_failed = true;
+    }
+    assertTrue(negative_sqrt_failed);
+  }
+};
+
+class comparison_test : public Test {
+public:
+  void run() {
+    assertTrue(bigint(50) > bigint(25));
+    assertTrue(bigint("999999999999999999") > bigint("888888888888888888"));
+    assertTrue(bigint("111111111111111111") < bigint("222222222222222222"));
+    assertTrue(bigint("999999999999999999999999999999999") <=
+               bigint("999999999999999999999999999999999"));
+    assertTrue(bigint("8888888888888888888") <= bigint("9999999999999999999"));
+    assertTrue(bigint("3333333333333333333") >= bigint("3333333333333333333"));
+    assertTrue(bigint("3333333333333333333") >= bigint("2222222222222222222"));
+    assertTrue(bigint("-100") < bigint("-2"));
+    assertTrue(bigint("-2") > bigint("-100"));
+    assertTrue(bigint("-100") <= bigint("-100"));
+    assertTrue(bigint("-2") >= bigint("-100"));
+    assertTrue(bigint("-1") < bigint("0"));
+    assertTrue(bigint("0") > bigint("-1"));
+  }
+};
+
+class bit_size_test : public Test {
+public:
+  void run() {
+    assertTrue(bigint("0").sizeInBits() == 0);
+    assertTrue(bigint("1").sizeInBits() == 1);
+    assertTrue(bigint("1000", 2).sizeInBits() == 4);
+    assertTrue(bigint("ffffffffffffffffffff", 16).sizeInBits() == 80);
+  }
+};
+
+int main(int, char **) {
+  TestSuite suite;
+  suite.add("Construction", new construction_test());
+  suite.add("Radix", new radix_test());
+  suite.add("Sign", new sign_test());
+  suite.add("Arithmetic", new arithmetic_test());
+  suite.add("Power", new power_test());
+  suite.add("Division", new division_test());
+  suite.add("Square root", new sqrt_test());
+  suite.add("Comparison", new comparison_test());
+  suite.add("Bit size", new bit_size_test());
+
+  suite.run();
+  suite.printStatus();
+  return suite.hasFailures() ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/src/scheme/testscheme.cpp
+++ b/src/scheme/testscheme.cpp
@@ -1603,128 +1603,6 @@ void test_garbagecollect() {
   assert_eval(s, L"(equal? a c)", L"#t");
 }
 
-class test_bigint : public Test {
-public:
-  void run() {
-
-    // Constructor
-    assertTrue(bigint(123456789) == bigint("123456789"));
-
-    // Copy constructor
-    bigint b1 = bigint("10");
-    bigint b2 = b1;
-    b1 += 10;
-    assertTrue(b2 == bigint("10"));
-    assertTrue(b1 == bigint("20"));
-    assertTrue(bigint(0) * 10 == bigint(0));
-
-    // Constructor radix test
-    assertTrue(bigint("ff", 16) == bigint("255"));
-    assertTrue(bigint("10001", 2) == bigint("17"));
-
-    // toString()
-    assertTrue(bigint(1000).toString() == "1000");
-    assertTrue(bigint(65535).toString(16) == "ffff");
-    assertTrue(bigint(-1000).toString() == "-1000");
-    assertTrue(bigint("123456789123456789").toString() == "123456789123456789");
-
-    // Zero handling
-    assertTrue(bigint("0") == bigint("-0"));
-    assertTrue(bigint("0").is_zero());
-    assertTrue(bigint("-0").is_zero());
-
-    // Negatives
-    assertTrue(bigint(-100) == bigint("-100"));
-    assertTrue(-bigint(100) == bigint(-100));
-    assertTrue(bigint(-1000) + bigint(1000) == bigint(0));
-    assertTrue(bigint("-1000") + bigint("1000") == bigint("0"));
-
-    // Subtraction
-    assertTrue(bigint(100) - 20 == bigint(80));
-    assertTrue(bigint(100) - bigint(3) == bigint(97));
-    assertTrue(bigint("3333333333333333333") - bigint("2222222222222222222") ==
-               bigint("1111111111111111111"));
-
-    // Addition
-    assertTrue((bigint(123456789) + 123456789) + 123456789 ==
-               bigint("370370367"));
-    assertTrue(bigint("999999999999999999999999999999999") +
-                   bigint("999999999999999999999999999999999") ==
-               bigint("1999999999999999999999999999999998"));
-    assertTrue(abs(bigint("-111111111111111111")) ==
-               bigint("111111111111111111"));
-
-    // Multiply
-    assertTrue(bigint("1000") * 10 == bigint("10000"));
-    assertTrue(bigint("123456789123456789") * bigint("123456789123456789") ==
-               bigint("15241578780673678515622620750190521"));
-    assertTrue((bigint("123456789") * 123456789) * 123456789 ==
-               bigint("1881676371789154860897069"));
-
-    // expt
-    assertTrue(bigint("100").expt(2) == bigint("10000"));
-    assertTrue(bigint("2").expt(0) == bigint(1));
-    assertTrue(bigint(0).expt(100) == bigint(0));
-    assertTrue(bigint(31).expt(19) == bigint("21670662219970396194714277471"));
-    assertTrue(bigint(17).expt(1000) * bigint(17).expt(500) ==
-               bigint(17).expt(1500));
-    assertTrue(bigint(31).expt(1000) * bigint(31).expt(1500) ==
-               bigint(31).expt(2500));
-
-    // Division
-    assertTrue(bigint("9999999999999999999") / 3 ==
-               bigint("3333333333333333333"));
-    assertTrue(bigint(-1000) / 10 == bigint(-100));
-    assertTrue(bigint(1000) / (-10) == bigint(-100));
-    assertTrue(bigint(-1000) / (-10) == bigint(100));
-    assertTrue(bigint(100) / bigint(2) == bigint(50));
-    assertTrue(bigint(100) / bigint(-2) == bigint(-50));
-    assertTrue(bigint(100) / bigint(1000) == bigint(0));
-    assertTrue(bigint(-100) / bigint(1000) == bigint(0));
-    assertTrue(bigint(100) / bigint(-1000) == bigint(0));
-    assertTrue(bigint("123456789123456789") / bigint("123456789123456789") ==
-               bigint(1));
-    assertTrue(bigint("10000000000") / bigint("1000000000") == bigint(10));
-    assertTrue(bigint("10000000000") / bigint("10000000") == bigint(1000));
-    assertTrue(bigint("993850124034") / bigint("1209237") == bigint("821882"));
-    assertTrue(bigint("993850124034") / bigint("821882") == bigint("1209237"));
-    // assertTrue(bigint("") / bigint("") == bigint(""));
-    assertTrue(bigint("123456789123456789") / bigint(1) ==
-               bigint("123456789123456789"));
-    assertTrue(bigint("10000000000") / bigint("10") == bigint("1000000000"));
-    assertTrue(bigint("15241578780673678515622620750190521") / bigint("1") ==
-               bigint("15241578780673678515622620750190521"));
-    // assertTrue(bigint("15241578780673678515622620750190521") /
-    // bigint("123456789123456789") == bigint("123456789123456789"));
-
-    // Remainder
-    assertTrue(bigint(100) % 10 == 0);
-    assertTrue(bigint("10000000000000000000000") % 3 == 1);
-    assertTrue(bigint("-99999999999999999992") % 3 == -2);
-
-    // Square root
-    assertTrue(bigint(100).sqrt() == bigint(10));
-    assertTrue(bigint(10000).sqrt() == bigint(100));
-    // assertTrue(bigint("10000000000000000").sqrt() == bigint("100000000"));
-    // assertTrue(bigint("15241578780673678515622620750190521").sqrt() ==
-    // bigint("123456789123456789"));
-
-    // Comparators
-    assertTrue(bigint(50) > bigint(25));
-    assertTrue(bigint("999999999999999999") > bigint("888888888888888888"));
-    assertTrue(bigint("111111111111111111") < bigint("222222222222222222"));
-    assertTrue(bigint("999999999999999999999999999999999") <=
-               bigint("999999999999999999999999999999999"));
-    assertTrue(bigint("8888888888888888888") <= bigint("9999999999999999999"));
-    assertTrue(bigint("3333333333333333333") >= bigint("3333333333333333333"));
-    assertTrue(bigint("3333333333333333333") >= bigint("2222222222222222222"));
-
-    // Bitsizes
-    assertTrue(bigint("1000", 2).sizeInBits() == 4);
-    assertTrue(bigint("ffffffffffffffffffff", 16).sizeInBits() == 80);
-  }
-};
-
 void test_lib_sorting() {
   Scheme *s = new Scheme();
   assert_eval(s, L"(list-sort < '(9 4 8 7 8 2 0))", L"(0 2 4 7 8 8 9)");
@@ -1918,7 +1796,6 @@ void test_lib_io_ports() {
 int main(int, char **) {
   TestSuite suite;
   suite.add("Parser", new test_parser());
-  // suite.add("Bigint", new test_bigint());
   suite.add("Vector", new test_vector());
 
   try {


### PR DESCRIPTION
## Summary
- move the old inactive bigint checks out of testscheme.cpp into a dedicated src/scheme/testbigint.cpp
- expand bigint coverage across construction, radix roundtrips, signs, arithmetic, division identities, sqrt, comparisons, and bit sizes
- add testbigint to both CMake and the legacy scheme Makefile.am
- fix bigint edge cases exposed by the new test: zero string conversion, negative zero, times_two, negative comparisons, division by zero/equality, and sqrt convergence

Note: the square() optimization TODO is intentionally left for a later PR.

## Tested
- ctest --test-dir build --output-on-failure -R testbigint
- ctest --test-dir build --output-on-failure