### PR TITLE
Validate Scheme let bindings

### DIFF
--- a/src/scheme/interpreter.cpp
+++ b/src/scheme/interpreter.cpp
@@ -1270,6 +1270,35 @@ fn_ptr eval_case(Interpreter::State *state) {
   return NULL;
 }
 
+static SchemeObject *validate_let_binding(Scheme *scheme, SchemeObject *binding,
+                                          const wchar_t *form_name) {
+  if (i_pair_p(binding) == S_FALSE ||
+      i_pair_p(s_cdr(scheme, binding)) == S_FALSE ||
+      s_cddr(scheme, binding) != S_EMPTY_LIST) {
+    throw scheme_exception(L"Bad binding in " + wstring(form_name) + L": " +
+                           binding->toString());
+  }
+
+  SchemeObject *symbol = s_car(scheme, binding);
+  if (i_symbol_p(symbol) == S_FALSE) {
+    throw scheme_exception(L"Bad variable in " + wstring(form_name) + L": " +
+                           symbol->toString());
+  }
+  return symbol;
+}
+
+static void reject_duplicate_let_binding(vector<SchemeObject *> &symbols,
+                                         SchemeObject *symbol,
+                                         const wchar_t *form_name) {
+  for (uint32_t i = 0; i < symbols.size(); i++) {
+    if (symbols[i] == symbol) {
+      throw scheme_exception(L"Duplicate variable in " + wstring(form_name) +
+                             L": " + symbol->toString());
+    }
+  }
+  symbols.push_back(symbol);
+}
+
 fn_ptr eval_let(Interpreter::State *state) {
   SchemeObject *p = state->global_arg1;
   SchemeObject *envt = state->global_envt;
@@ -1280,6 +1309,10 @@ fn_ptr eval_let(Interpreter::State *state) {
   }
 
   SchemeObject *first_arg = i_car(p);
+
+  if (i_null_p(s_cdr(scheme, p)) == S_TRUE) {
+    throw scheme_exception(L"Missing body in let");
+  }
 
   if (i_symbol_p(first_arg) == S_TRUE) {
     return (fn_ptr)&eval_named_let;
@@ -1294,16 +1327,18 @@ fn_ptr eval_let(Interpreter::State *state) {
   SchemeObject *binding_pairs = first_arg;
 
   state->stack.push_back(new_bindings);
+  vector<SchemeObject *> symbols;
 
   while (i_null_p(binding_pairs) == S_FALSE) {
-    // Eval binding value
+    SchemeObject *binding_pair = s_car(scheme, binding_pairs);
+    SchemeObject *symbol = validate_let_binding(scheme, binding_pair, L"let");
+    reject_duplicate_let_binding(symbols, symbol, L"let");
 
-    state->global_arg1 =
-        s_car(scheme, s_cdr(scheme, s_car(scheme, binding_pairs)));
+    // Eval binding value
+    state->global_arg1 = s_cadr(scheme, binding_pair);
     SchemeObject *val = trampoline((fn_ptr)&eval, state);
 
-    new_bindings->defineBinding(s_car(scheme, s_car(scheme, binding_pairs)),
-                                val);
+    new_bindings->defineBinding(symbol, val);
     binding_pairs = s_cdr(scheme, binding_pairs);
   }
   state->stack.pop_back();
@@ -1321,6 +1356,10 @@ fn_ptr eval_named_let(Interpreter::State *state) {
   SchemeObject *name = s_car(scheme, p);
   p = s_cdr(scheme, p);
 
+  if (i_null_p(s_cdr(scheme, p)) == S_TRUE) {
+    throw scheme_exception(L"Missing body in let");
+  }
+
   if (i_pair_p(s_car(scheme, p)) == S_FALSE &&
       i_null_p(s_car(scheme, p)) == S_FALSE) {
     throw scheme_exception(L"Bad formals in let");
@@ -1330,11 +1369,14 @@ fn_ptr eval_named_let(Interpreter::State *state) {
   SchemeObject *binding_pairs = s_car(scheme, p);
   SchemeAppendableList formals;
   SchemeAppendableList args;
+  vector<SchemeObject *> symbols;
 
   while (i_null_p(binding_pairs) == S_FALSE) {
     SchemeObject *binding_pair = s_car(scheme, binding_pairs);
-    SchemeObject *formal = s_car(scheme, binding_pair);
-    SchemeObject *arg = s_car(scheme, s_cdr(scheme, binding_pair));
+    SchemeObject *formal =
+        validate_let_binding(scheme, binding_pair, L"named let");
+    reject_duplicate_let_binding(symbols, formal, L"named let");
+    SchemeObject *arg = s_cadr(scheme, binding_pair);
 
     formals.add(formal);
     args.add(arg);
@@ -1376,17 +1418,14 @@ fn_ptr eval_letstar(Interpreter::State *state) {
   SchemeObject *binding_pairs = s_car(scheme, p);
 
   while (i_null_p(binding_pairs) == S_FALSE) {
+    SchemeObject *binding_pair = s_car(scheme, binding_pairs);
+    SchemeObject *sym = validate_let_binding(scheme, binding_pair, L"let*");
+
     // Eval binding value
-    state->global_arg1 = s_cadar(scheme, binding_pairs);
+    state->global_arg1 = s_cadr(scheme, binding_pair);
     state->global_envt = new_bindings;
     SchemeObject *val = trampoline((fn_ptr)&eval, state);
 
-    SchemeObject *sym = s_car(scheme, s_car(scheme, binding_pairs));
-    if (i_symbol_p(sym) == S_FALSE) {
-      throw scheme_exception(
-          L"Bad variable in let*: " +
-          s_car(scheme, s_car(scheme, binding_pairs))->toString());
-    }
     new_bindings->defineBinding(sym, val);
     binding_pairs = s_cdr(scheme, binding_pairs);
   }

--- a/src/scheme/testscheme.cpp
+++ b/src/scheme/testscheme.cpp
@@ -1377,13 +1377,23 @@ void test_let() {
       L"#t");
 
   assert_fail(s, L"(let)");
+  assert_fail(s, L"(let ())");
   assert_fail(s, L"(let 'a)");
   assert_fail(s, L"(let 'a 'b)");
+  assert_fail(s, L"(let ((1 2)) 1)");
+  assert_fail(s, L"(let ((x 1 2)) x)");
+  assert_fail(s, L"(let ((x 1) (x 2)) x)");
   assert_fail(s, L"(let loop 'b)");
   assert_fail(s, L"(let loop 'b 'c)");
+  assert_fail(s, L"(let loop ())");
+  assert_fail(s, L"(let loop ((1 2)) 1)");
+  assert_fail(s, L"(let loop ((x 1 2)) x)");
+  assert_fail(s, L"(let loop ((x 1) (x 2)) x)");
   assert_fail(s, L"(let*)");
   assert_fail(s, L"(let* 'a)");
   assert_fail(s, L"(let* 'a 'b)");
+  assert_fail(s, L"(let* ((x 1 2)) x)");
+  assert_eval(s, L"(let* ((x 1) (x 2)) x)", L"2");
   assert_fail(s, L"(letrec)");
   assert_fail(s, L"(letrec 'a)");
   assert_fail(s, L"(letrec 'a 'b)");


### PR DESCRIPTION
## Summary
- reject malformed let, named let, and let* bindings instead of silently accepting them
- reject duplicate variables in let and named let bindings
- reject missing bodies for let and named let forms
- add tests covering malformed bindings, duplicate variables, and let* duplicate shadowing

## Tests
- cmake --build build --target testscheme
- ./build/testscheme
- ctest --test-dir build --output-on-failure