### PR TITLE
Use thread_local for thread-specific caches

### DIFF
--- a/src/cameras/camera.cpp
+++ b/src/cameras/camera.cpp
@@ -4,7 +4,23 @@
 #include "math/functions.h"
 #include "ray.h"
 
+#include <atomic>
+#include <map>
+
+namespace {
+uint64_t nextCameraDofQmcId() {
+  static std::atomic<uint64_t> next_id(0);
+  return ++next_id;
+}
+
+std::map<uint64_t, QMCSequence *> &cameraDofQmcs() {
+  static thread_local std::map<uint64_t, QMCSequence *> qmcs;
+  return qmcs;
+}
+} // namespace
+
 Camera::Camera() {
+  dof_qmc_id = nextCameraDofQmcId();
   aa_enabled = false;
   dof_enabled = false;
   zoom_enabled = false;
@@ -24,6 +40,7 @@ Camera::Camera() {
  */
 Camera::Camera(Vector position, Vector lookAt, Vector up, double fieldOfView,
                int width, int height) {
+  dof_qmc_id = nextCameraDofQmcId();
   aa_enabled = false;
   dof_enabled = false;
   zoom_enabled = false;
@@ -37,8 +54,12 @@ Camera::Camera(Vector position, Vector lookAt, Vector up, double fieldOfView,
 }
 
 Camera::~Camera() {
-  if (dof_enabled)
-    delete get_dof_qmc();
+  std::map<uint64_t, QMCSequence *> &qmcs = cameraDofQmcs();
+  std::map<uint64_t, QMCSequence *>::iterator i = qmcs.find(dof_qmc_id);
+  if (i != qmcs.end()) {
+    delete i->second;
+    qmcs.erase(i);
+  }
 }
 
 void Camera::init() {
@@ -73,7 +94,6 @@ void Camera::enableDoF(double aperture, int samples, const Vector &focalpoint) {
   this->dof_samples = samples;
   this->dof_enabled = true;
   this->dof_sample_count = 0;
-  pthread_key_create(&dof_qmc_key, NULL);
 }
 
 void Camera::transform(const Matrix &m) {
@@ -150,12 +170,15 @@ void Camera::resetQMC() {
 }
 
 QMCSequence *Camera::get_dof_qmc() {
-  QMCSequence *qmc = (QMCSequence *)pthread_getspecific(dof_qmc_key);
-  if (qmc == NULL) {
+  std::map<uint64_t, QMCSequence *> &qmcs = cameraDofQmcs();
+  std::map<uint64_t, QMCSequence *>::iterator i = qmcs.find(dof_qmc_id);
+  if (i == qmcs.end()) {
+    QMCSequence *qmc;
     qmc = new Halton(2, 2);
-    pthread_setspecific(dof_qmc_key, qmc);
+    qmcs[dof_qmc_id] = qmc;
+    return qmc;
   }
-  return qmc;
+  return i->second;
 }
 
 void Camera::setZoom(const Vector2 &pos, double width) {

--- a/src/cameras/camera.h
+++ b/src/cameras/camera.h
@@ -6,6 +6,7 @@
 #include "math/vector.h"
 #include "math/vector2.h"
 #include "samplers/sampler.h"
+#include <stdint.h>
 
 class Ray;
 
@@ -86,7 +87,7 @@ private:
   void init();
   SamplerFactory *sampler_factory;
   QMCSequence *get_dof_qmc();
-  pthread_key_t dof_qmc_key;
+  uint64_t dof_qmc_id;
   double aspect_ratio; ///< height / width in output image
   Vector2 zoom_pos;
   double zoom_width;

--- a/src/lights/arealight.cpp
+++ b/src/lights/arealight.cpp
@@ -7,7 +7,22 @@
 #include "math/vector.h"
 #include "paths/circle.h"
 
+#include <atomic>
+#include <map>
+
 class KdTree;
+
+namespace {
+uint64_t nextArealightShadowCacheId() {
+  static std::atomic<uint64_t> next_id(0);
+  return ++next_id;
+}
+
+std::map<uint64_t, std::vector<ShadowCache> > &arealightShadowCaches() {
+  static thread_local std::map<uint64_t, std::vector<ShadowCache> > caches;
+  return caches;
+}
+} // namespace
 
 /**
  * Constructs an area light
@@ -25,8 +40,7 @@ Arealight::Arealight(const Vector &pos, const Vector &dir, double radius,
 
   this->num = num;
   this->jitter = jitter;
-
-  pthread_key_create(&shadowcaches_key, NULL);
+  this->shadowcache_id = nextArealightShadowCacheId();
 
   /* De N punkter skal placeres på N koncentriske bånd omkring P. Disse
    * N bånd skal have samme areal A, så punkterne er dækker cirklens
@@ -105,14 +119,13 @@ bool Arealight::probeSublight(uint32_t i, const Intersection &inter,
 
   Ray ray_to_light = Ray(surface_point, direction_to_light, -1.0);
 
-  std::vector<ShadowCache> *shadowcaches =
-      (std::vector<ShadowCache> *)pthread_getspecific(shadowcaches_key);
-  if (shadowcaches == NULL) {
-    shadowcaches = new std::vector<ShadowCache>(num);
-    pthread_setspecific(shadowcaches_key, shadowcaches);
+  std::vector<ShadowCache> &shadowcaches =
+      arealightShadowCaches()[shadowcache_id];
+  if (shadowcaches.size() != num) {
+    shadowcaches = std::vector<ShadowCache>(num);
   }
 
   bool occluded =
-      (*shadowcaches)[i].occluded(ray_to_light, dist_to_light, depth, space);
+      shadowcaches[i].occluded(ray_to_light, dist_to_light, depth, space);
   return occluded;
 }

--- a/src/lights/arealight.h
+++ b/src/lights/arealight.h
@@ -3,6 +3,7 @@
 
 #include "lights/lightsource.h"
 #include "lights/shadowcache.h"
+#include <stdint.h>
 #include <vector>
 
 class Circle;
@@ -26,7 +27,7 @@ private:
   std::vector<Circle *> circles;
   std::vector<double> ts;
   double jitter;
-  pthread_key_t shadowcaches_key;
+  uint64_t shadowcache_id;
   uint32_t num;
 
   Vector getPosition(uint32_t i) const;

--- a/src/lights/pointlight.cpp
+++ b/src/lights/pointlight.cpp
@@ -5,21 +5,31 @@
 #include "lights/shadowcache.h"
 #include "objects/object.h"
 
+#include <atomic>
+#include <map>
+
 class KdTree;
 
+namespace {
+uint64_t nextPointlightShadowCacheId() {
+  static std::atomic<uint64_t> next_id(0);
+  return ++next_id;
+}
+
+std::map<uint64_t, ShadowCache> &pointlightShadowCaches() {
+  static thread_local std::map<uint64_t, ShadowCache> caches;
+  return caches;
+}
+} // namespace
+
 Pointlight::Pointlight(const Vector &pos) : Lightsource(pos) {
-  pthread_key_create(&shadowcache_key, NULL);
+  shadowcache_id = nextPointlightShadowCacheId();
 }
 
 void Pointlight::getLightinfo(const Intersection &inter, KdTree *space,
                               Lightinfo *info, uint32_t depth) const {
 
-  ShadowCache *shadowcache =
-      (ShadowCache *)pthread_getspecific(shadowcache_key);
-  if (shadowcache == NULL) {
-    shadowcache = new ShadowCache();
-    pthread_setspecific(shadowcache_key, shadowcache);
-  }
+  ShadowCache *shadowcache = &pointlightShadowCaches()[shadowcache_id];
 
   // Move intersection point ESPILON along surface normal to
   // avoid selfshadowing.

--- a/src/lights/pointlight.h
+++ b/src/lights/pointlight.h
@@ -3,6 +3,7 @@
 #define POINTLIGHT_H
 
 #include "lights/lightsource.h"
+#include <stdint.h>
 
 class RGB;
 class Matrix;
@@ -19,7 +20,7 @@ public:
                     uint32_t depth) const;
 
 private:
-  pthread_key_t shadowcache_key;
+  uint64_t shadowcache_id;
 };
 
 #endif

--- a/src/lights/skylight.cpp
+++ b/src/lights/skylight.cpp
@@ -4,14 +4,28 @@
 #include "math/functions.h"
 #include "math/halton.h"
 
+#include <atomic>
+#include <map>
+
 class KdTree;
+
+namespace {
+uint64_t nextSkylightShadowCacheId() {
+  static std::atomic<uint64_t> next_id(0);
+  return ++next_id;
+}
+
+std::map<uint64_t, std::vector<ShadowCache> > &skylightShadowCaches() {
+  static thread_local std::map<uint64_t, std::vector<ShadowCache> > caches;
+  return caches;
+}
+} // namespace
 
 Skylight::Skylight(double radius, uint32_t num) : Lightsource(Vector(0, 0, 0)) {
   this->radius = radius;
   this->num = num;
+  this->shadowcache_id = nextSkylightShadowCacheId();
   Halton qmc = Halton(2, 2);
-
-  pthread_key_create(&shadowcaches_key, NULL);
 
   for (int i = 0; i < num; i++) {
     Vector pos = Math::perturbVector(Vector(0, 1, 0), DEG2RAD(89), &qmc);
@@ -65,11 +79,10 @@ void Skylight::getSingleLightinfo(const Intersection &inter, KdTree *space,
 
 bool Skylight::probe(uint32_t i, const Ray &ray, double dist, uint32_t depth,
                      KdTree *space) const {
-  std::vector<ShadowCache> *shadowcaches =
-      (std::vector<ShadowCache> *)pthread_getspecific(shadowcaches_key);
-  if (shadowcaches == NULL) {
-    shadowcaches = new std::vector<ShadowCache>(num);
-    pthread_setspecific(shadowcaches_key, shadowcaches);
+  std::vector<ShadowCache> &shadowcaches =
+      skylightShadowCaches()[shadowcache_id];
+  if (shadowcaches.size() != num) {
+    shadowcaches = std::vector<ShadowCache>(num);
   }
-  return (*shadowcaches)[i].occluded(ray, dist, depth, space);
+  return shadowcaches[i].occluded(ray, dist, depth, space);
 }

--- a/src/lights/skylight.h
+++ b/src/lights/skylight.h
@@ -3,6 +3,7 @@
 
 #include "lights/lightsource.h"
 #include "lights/shadowcache.h"
+#include <stdint.h>
 #include <vector>
 
 class Object;
@@ -21,7 +22,7 @@ public:
 
 private:
   std::vector<Vector> positions;
-  pthread_key_t shadowcaches_key;
+  uint64_t shadowcache_id;
   double radius;
   uint32_t num;
 

--- a/src/scheme/heap.cpp
+++ b/src/scheme/heap.cpp
@@ -22,7 +22,6 @@ Heap::Heap(uint32_t page_size) {
   gc_runs = 0;
 
   pthread_mutex_init(&mutex_reserve, NULL);
-  pthread_key_create(&local_bank_key, NULL);
 
   allocateNewPage();
 }
@@ -49,12 +48,8 @@ void Heap::allocateNewPage() {
 
 SchemeObject *Heap::allocate(SchemeObject::ObjectType type) {
   assert((int)type < 256);
-  ThreadLocalCache *local =
-      (ThreadLocalCache *)pthread_getspecific(local_bank_key);
-  if (local == NULL) {
-    local = new ThreadLocalCache();
-    pthread_setspecific(local_bank_key, local);
-  }
+  static thread_local ThreadLocalCache thread_local_cache;
+  ThreadLocalCache *local = &thread_local_cache;
 
   if (local->index >= SIZE_OF_LOCAL_SLOTS) {
     reserve(local->bank, SIZE_OF_LOCAL_SLOTS);

--- a/src/scheme/heap.h
+++ b/src/scheme/heap.h
@@ -69,7 +69,6 @@ private: /* Thread local stuff */
     uint32_t index;
   };
 
-  pthread_key_t local_bank_key;
   pthread_mutex_t mutex_reserve;
 };
 

--- a/src/scheme/interpreter.cpp
+++ b/src/scheme/interpreter.cpp
@@ -3,16 +3,30 @@
 #include "r6rs-lib-lists.h"
 #include "scheme.h"
 
+#include <atomic>
 #include <iostream>
+#include <map>
 #include <vector>
 
 using namespace std;
+
+namespace {
+uint64_t nextInterpreterStateId() {
+  static atomic<uint64_t> next_id(0);
+  return ++next_id;
+}
+
+map<uint64_t, Interpreter::State *> &threadLocalStates() {
+  static thread_local map<uint64_t, Interpreter::State *> states;
+  return states;
+}
+} // namespace
 
 //------------------------------------------------------------------------
 // Interpreter
 //------------------------------------------------------------------------
 Interpreter::Interpreter(Scheme *scheme) {
-  pthread_key_create(&state_key, NULL);
+  state_id = nextInterpreterStateId();
   this->scheme = scheme;
 }
 
@@ -107,16 +121,18 @@ SchemeObject *Interpreter::interpret(SchemeObject *parsetree,
 }
 
 Interpreter::State *Interpreter::getState() {
-  State *state = (State *)pthread_getspecific(state_key);
-  if (state == NULL) {
+  map<uint64_t, Interpreter::State *> &states = threadLocalStates();
+  map<uint64_t, Interpreter::State *>::iterator i = states.find(state_id);
+  if (i == states.end()) {
     // TODO: Register the new state in a list.
     // We need states of all threads when calling
     // for garbage-collection.
-    state = new Interpreter::State();
+    State *state = new Interpreter::State();
     state->scheme = scheme;
-    pthread_setspecific(state_key, state);
+    states[state_id] = state;
+    return state;
   }
-  return state;
+  return i->second;
 }
 
 // A popular method for achieving proper tail recursion in a non-tail-recursive

--- a/src/scheme/interpreter.h
+++ b/src/scheme/interpreter.h
@@ -5,7 +5,7 @@
 #include "objects.h"
 #include "scheme.h"
 #include <csetjmp>
-#include <pthread.h>
+#include <stdint.h>
 #include <vector>
 
 #define INTERPRETER_MAX_STACK_SIZE 10000
@@ -38,7 +38,7 @@ public:
   State *getState();
 
 private:
-  pthread_key_t state_key;
+  uint64_t state_id;
   Scheme *scheme;
 };
 


### PR DESCRIPTION
Replaces pthread TLS keys with C++11 thread_local storage for Scheme interpreter state, Scheme heap local banks, light shadow caches, and camera DoF QMC sequences. Per-instance cache ids preserve the old per-object TLS behavior while removing pthread_getspecific and pthread_setspecific.

Verified locally:
- cmake --build build --target raygay testscheme testobjects testspace
- ctest --test-dir build --output-on-failure
- build/raygay -j 4 -b scenes/benchmarkscene.scm /private/tmp/raygay-thread-local-benchmark-j4.tga