### PR TITLE
Add optional OpenEXR image support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,12 +43,12 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang cmake g++ gcc libjpeg-dev libpng-dev ninja-build pkg-config
+          sudo apt-get install -y clang cmake g++ gcc libjpeg-dev libpng-dev libopenexr-dev ninja-build pkg-config
 
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
         run: |
-          brew install cmake ninja pkg-config
+          brew install cmake ninja pkg-config openexr
 
       - name: Configure
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 
 find_package(Threads REQUIRED)
+find_package(OpenEXR CONFIG QUIET)
 if(APPLE)
   find_package(PNG QUIET)
   find_package(JPEG QUIET)
@@ -68,6 +69,7 @@ endif()
 set(HAVE_PNG_H ${PNG_FOUND})
 set(HAVE_JPEGLIB_H ${JPEG_FOUND})
 set(HAVE_PTHREAD_H ${CMAKE_USE_PTHREADS_INIT})
+set(HAVE_OPENEXR ${OpenEXR_FOUND})
 
 if(UNIX AND NOT APPLE)
   find_library(MATH_LIBRARY m)
@@ -229,6 +231,7 @@ set(RAYGAY_TRACER_SOURCES
   src/image/imageio.cpp
   src/image/imageio_tga.cpp
   src/image/imageio_hdri.cpp
+  src/image/imageio_openexr.cpp
   src/image/imageio_jpeg.cpp
   src/image/imageio_png.cpp
   src/image/imageio_darwin.cpp
@@ -325,6 +328,9 @@ if(PNG_FOUND)
 endif()
 if(JPEG_FOUND)
   target_link_libraries(raygay_tracer PUBLIC JPEG::JPEG)
+endif()
+if(OpenEXR_FOUND)
+  target_link_libraries(raygay_tracer PUBLIC OpenEXR::OpenEXR)
 endif()
 
 set(RAYGAY_HTTP_SOURCES

--- a/INSTALL
+++ b/INSTALL
@@ -15,13 +15,14 @@ Required everywhere:
 
 macOS builds require macOS 11.0 or newer.
 
-Linux also needs libpng and libjpeg development headers:
+Linux also needs libpng and libjpeg development headers. OpenEXR is optional,
+but enables `.exr` HDR image input and output:
 
-  sudo apt-get install cmake ninja-build g++ libpng-dev libjpeg-dev pkg-config
+  sudo apt-get install cmake ninja-build g++ libpng-dev libjpeg-dev libopenexr-dev pkg-config
 
 On macOS with Homebrew:
 
-  brew install cmake ninja pkg-config
+  brew install cmake ninja pkg-config openexr
 
 PNG and JPEG libraries are optional on macOS because RayGay can use Apple's
 ApplicationServices image loading path there. Install them if you want CMake to
@@ -52,6 +53,7 @@ RayGay detects some optional features automatically:
 
   - readline support for raygay-repl, when readline headers and library exist
   - GTK 2 preview window support, when gtk+-2.0 is available through pkg-config
+  - OpenEXR `.exr` image support, when OpenEXR is available
 
 MPI support is off by default. Enable it explicitly:
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@ require macOS 11.0 or newer.
 
 On macOS with Homebrew:
 
-    brew install cmake ninja pkg-config
+    brew install cmake ninja pkg-config openexr
 
 On Ubuntu/Debian:
 
-    sudo apt-get install cmake ninja-build g++ libjpeg-dev libpng-dev pkg-config
+    sudo apt-get install cmake ninja-build g++ libjpeg-dev libpng-dev libopenexr-dev pkg-config
+
+OpenEXR is optional. When found, RayGay can load and save `.exr` images with
+HDR values preserved.
 
 The C++ source code is in `src`. Compile with:
 

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -14,6 +14,7 @@
 #cmakedefine HAVE_LONG_DOUBLE_WIDER 1
 #cmakedefine HAVE_MPI 1
 #cmakedefine HAVE_NDIR_H 1
+#cmakedefine HAVE_OPENEXR 1
 #cmakedefine HAVE_PNG_H 1
 #cmakedefine HAVE_PTHREAD_H 1
 #cmakedefine HAVE_STDINT_H 1

--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,11 @@ AM_CONDITIONAL(OS_DARWIN, test "x$target_os" = "xDarwin")
 dnl -------------------------------------------------
 dnl Image libs
 dnl -------------------------------------------------
+PKG_PROG_PKG_CONFIG
+PKG_CHECK_MODULES([OPENEXR], [OpenEXR],
+  [AC_DEFINE([HAVE_OPENEXR], [1], [Define if OpenEXR is available])],
+  [:])
+
 if test "x$target_os" = "xLinux"; then
    AC_CHECK_LIB(jpeg, jpeg_read_header,JPEG_LIBS="-ljpeg")
    AC_CHECK_LIB(png, png_read_info, PNG_LIBS="-lpng")
@@ -146,7 +151,6 @@ AS_IF([test "x$with_readline" != xno],
 dnl -------------------------------------------------
 dnl Check for GTK
 dnl -------------------------------------------------
-PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES(GTK, [gtk+-2.0 >= 1.3],[gtk_found="yes"],[gtk_found="no"]) 
 AC_MSG_RESULT([$gtk_found])
 if test "x$gtk_found" = "xyes"; then

--- a/src/image/Makefile.am
+++ b/src/image/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I$(top_srcdir)/src 
+AM_CPPFLAGS = -I$(top_srcdir)/src @OPENEXR_CFLAGS@
 
 noinst_LTLIBRARIES = libimage.la
 
@@ -14,12 +14,13 @@ libimage_la_SOURCES = image.cpp \
                      imageio.cpp \
 		     imageio_tga.cpp \
 		     imageio_hdri.cpp \
+		     imageio_openexr.cpp \
 		     imageio_jpeg.cpp \
 		     imageio_png.cpp \
 		     imageio_darwin.cpp \
 		     imagedrawing.cpp
 
-libimage_la_LIBADD = @JPEG_LIBS@ @PNG_LIBS@
+libimage_la_LIBADD = @JPEG_LIBS@ @PNG_LIBS@ @OPENEXR_LIBS@
 libimage_la_LDFLAGS = @DARWIN_LIBS@ 
 
 EXTRA_DIST = image.h 		\
@@ -27,6 +28,7 @@ EXTRA_DIST = image.h 		\
 	imageio_jpeg.h	\
 	imageio_png.h	\
 	imageio_hdri.h	\
+	imageio_openexr.h	\
 	imageio_tga.h 	\
 	imageio_darwin.h	\
 	imagedrawing.h	\
@@ -35,4 +37,3 @@ EXTRA_DIST = image.h 		\
 	texture.h 	        \
 	simpletexture.h    \
 	multitexture.h
-

--- a/src/image/image.cpp
+++ b/src/image/image.cpp
@@ -9,6 +9,7 @@
 #include "image/imageio_darwin.h"
 #include "image/imageio_hdri.h"
 #include "image/imageio_jpeg.h"
+#include "image/imageio_openexr.h"
 #include "image/imageio_png.h"
 #include "image/imageio_tga.h"
 #include "math/vector2.h"
@@ -72,6 +73,13 @@ ImageIO *getImageIO(const std::string &filename) {
   } else if (filename.find(".hdr") != string::npos ||
              filename.find(".HDR") != string::npos) {
     io = new HdriIO();
+  } else if (filename.find(".exr") != string::npos ||
+             filename.find(".EXR") != string::npos) {
+#ifdef HAVE_OPENEXR
+    io = new OpenExrIO();
+#else
+    throw_exception("Support for OpenEXR-files is not compiled in.");
+#endif
 #ifdef OS_DARWIN
   } else if (filename.find(".jp2") != string::npos ||
              filename.find(".JP2") != string::npos) {
@@ -113,6 +121,8 @@ std::vector<std::string> Image::supportedFormats() {
     result.push_back("JPEG2000");
   if (supportsFormat(".hdr"))
     result.push_back("HDRI");
+  if (supportsFormat(".exr"))
+    result.push_back("OpenEXR");
   return result;
 }
 
@@ -120,7 +130,6 @@ std::vector<std::string> Image::supportedFormats() {
  * Writes the image into a  24 bit uncompressed tga-file
  */
 void Image::save(const std::string &filename) {
-  clipColors();
   ImageIO *io = getImageIO(filename);
   io->save(this, filename);
   delete io;

--- a/src/image/imageio_darwin.cpp
+++ b/src/image/imageio_darwin.cpp
@@ -28,7 +28,7 @@ void DarwinIO::save(const Image *const image,
   for (uint32_t y = 0; y < h; y++) {
     for (uint32_t x = 0; x < w; x++) {
       RGBA c = image->getRGBA(x, y);
-      c.clip();
+      c = c.clamped();
       data[4 * (x + y * w) + 0] = uint8_t(c.r() * c.a() * 255.0);
       data[4 * (x + y * w) + 1] = uint8_t(c.g() * c.a() * 255.0);
       data[4 * (x + y * w) + 2] = uint8_t(c.b() * c.a() * 255.0);

--- a/src/image/imageio_openexr.cpp
+++ b/src/image/imageio_openexr.cpp
@@ -7,6 +7,7 @@
 #include "exception.h"
 #include "image/imageimpl.h"
 #include "image/imageio_openexr.h"
+#include "math/functions.h"
 
 #include <ImfArray.h>
 #include <ImfRgbaFile.h>
@@ -26,7 +27,8 @@ void OpenExrIO::save(const Image *const image,
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {
       RGBA color = image->getRGBA(x, y);
-      pixels[y][x] = Rgba(color.r(), color.g(), color.b(), color.a());
+      pixels[y][x] = Rgba(color.r(), color.g(), color.b(),
+                          Math::clamp(color.a()));
     }
   }
 

--- a/src/image/imageio_openexr.cpp
+++ b/src/image/imageio_openexr.cpp
@@ -1,0 +1,74 @@
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#ifdef HAVE_OPENEXR
+
+#include "exception.h"
+#include "image/imageimpl.h"
+#include "image/imageio_openexr.h"
+
+#include <ImfArray.h>
+#include <ImfRgbaFile.h>
+#include <exception>
+#include <string>
+
+using namespace OPENEXR_IMF_NAMESPACE;
+
+void OpenExrIO::save(const Image *const image,
+                     const std::string &filename) const {
+  const int width = image->getWidth();
+  const int height = image->getHeight();
+
+  Array2D<Rgba> pixels;
+  pixels.resizeErase(height, width);
+
+  for (int y = 0; y < height; y++) {
+    for (int x = 0; x < width; x++) {
+      RGBA color = image->getRGBA(x, y);
+      pixels[y][x] = Rgba(color.r(), color.g(), color.b(), color.a());
+    }
+  }
+
+  try {
+    RgbaOutputFile file(filename.c_str(), width, height, WRITE_RGBA);
+    file.setFrameBuffer(&pixels[0][0], 1, width);
+    file.writePixels(height);
+  } catch (const std::exception &e) {
+    throw_exception("Error saving OpenEXR file " + filename + ": " + e.what());
+  }
+}
+
+void OpenExrIO::save(const Image *const image, FILE *file) const {
+  throw_exception("OpenEXR saving requires a filename.");
+}
+
+Image *OpenExrIO::load(const std::string &filename, Allocator::model_t model) {
+  try {
+    RgbaInputFile file(filename.c_str());
+    Imath::Box2i data_window = file.dataWindow();
+    int width = data_window.max.x - data_window.min.x + 1;
+    int height = data_window.max.y - data_window.min.y + 1;
+
+    Array2D<Rgba> pixels;
+    pixels.resizeErase(height, width);
+    file.setFrameBuffer(&pixels[0][0] - data_window.min.x -
+                            data_window.min.y * width,
+                        1, width);
+    file.readPixels(data_window.min.y, data_window.max.y);
+
+    Image *result = new ImageImpl<float, 4>(width, height, model);
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        const Rgba &pixel = pixels[y][x];
+        result->setRGBA(x, y, RGBA(pixel.r, pixel.g, pixel.b, pixel.a));
+      }
+    }
+    return result;
+  } catch (const std::exception &e) {
+    throw_exception("Error reading OpenEXR file " + filename + ": " +
+                    e.what());
+  }
+}
+
+#endif /* HAVE_OPENEXR */

--- a/src/image/imageio_openexr.h
+++ b/src/image/imageio_openexr.h
@@ -1,0 +1,24 @@
+#ifndef IMAGE_OPENEXR_IO_H
+#define IMAGE_OPENEXR_IO_H
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#ifdef HAVE_OPENEXR
+
+#include "imageio.h"
+
+/**
+ * A loader and saver for OpenEXR image files.
+ */
+class OpenExrIO : public ImageIO {
+public:
+  void save(const Image *const image, const std::string &filename) const;
+  void save(const Image *const image, FILE *file) const;
+  Image *load(const std::string &filename,
+              Allocator::model_t = Allocator::AUTO);
+};
+
+#endif
+#endif

--- a/src/image/imageio_png.cpp
+++ b/src/image/imageio_png.cpp
@@ -92,6 +92,7 @@ png_set_text(png_ptr, info_ptr, text_ptr, 3);
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {
       RGBA pixel = image->getRGBA(x, y);
+      pixel = pixel.clamped();
       row[x * 4 + 0] = int(pixel.r() * 255);
       row[x * 4 + 1] = int(pixel.g() * 255);
       row[x * 4 + 2] = int(pixel.b() * 255);

--- a/src/image/imageio_tga.cpp
+++ b/src/image/imageio_tga.cpp
@@ -45,6 +45,7 @@ void TgaIO::save(const Image *const image, FILE *outfile) const {
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {
       color = image->getRGBA(x, (height - 1) - y);
+      color = color.clamped();
       bytes[4 * (x + y * width) + 0] = (uint8_t)(floor(color.b() * 255 + 0.5));
       bytes[4 * (x + y * width) + 1] = (uint8_t)(floor(color.g() * 255 + 0.5));
       bytes[4 * (x + y * width) + 2] = (uint8_t)(floor(color.r() * 255 + 0.5));

--- a/test/testimage.cpp
+++ b/test/testimage.cpp
@@ -275,7 +275,7 @@ public:
 class test_openexr : public Test {
 public:
   void run() {
-    RGBA bright = RGBA(4.0, 0.5, 12.0, 0.75);
+    RGBA bright = RGBA(4.0, 0.5, 12.0, 4.0);
     RGBA dim = RGBA(0.125, 2.0, 0.25, 1.0);
 
     Image *img = new ImageImpl<float, 4>(4, 3);
@@ -290,7 +290,7 @@ public:
     assertTrue(IS_SORTA_EQUAL(img2->getRGBA(0, 0).r(), bright.r()));
     assertTrue(IS_SORTA_EQUAL(img2->getRGBA(0, 0).g(), bright.g()));
     assertTrue(IS_SORTA_EQUAL(img2->getRGBA(0, 0).b(), bright.b()));
-    assertTrue(IS_SORTA_EQUAL(img2->getRGBA(0, 0).a(), bright.a()));
+    assertTrue(IS_SORTA_EQUAL(img2->getRGBA(0, 0).a(), 1.0));
     assertTrue(IS_SORTA_EQUAL(img2->getRGBA(3, 2).r(), dim.r()));
     assertTrue(IS_SORTA_EQUAL(img2->getRGBA(3, 2).g(), dim.g()));
     assertTrue(IS_SORTA_EQUAL(img2->getRGBA(3, 2).b(), dim.b()));

--- a/test/testimage.cpp
+++ b/test/testimage.cpp
@@ -260,6 +260,36 @@ public:
   }
 };
 
+class test_openexr : public Test {
+public:
+  void run() {
+    RGBA bright = RGBA(4.0, 0.5, 12.0, 0.75);
+    RGBA dim = RGBA(0.125, 2.0, 0.25, 1.0);
+
+    Image *img = new ImageImpl<float, 4>(4, 3);
+    img->setRGBA(0, 0, bright);
+    img->setRGBA(3, 2, dim);
+
+    img->save(getLoadPrefix() + "/test.exr");
+    Image *img2 = Image::load(getLoadPrefix() + "/test.exr");
+
+    assertTrue(img2->getWidth() == 4);
+    assertTrue(img2->getHeight() == 3);
+    assertTrue(IS_SORTA_EQUAL(img2->getRGBA(0, 0).r(), bright.r()));
+    assertTrue(IS_SORTA_EQUAL(img2->getRGBA(0, 0).g(), bright.g()));
+    assertTrue(IS_SORTA_EQUAL(img2->getRGBA(0, 0).b(), bright.b()));
+    assertTrue(IS_SORTA_EQUAL(img2->getRGBA(0, 0).a(), bright.a()));
+    assertTrue(IS_SORTA_EQUAL(img2->getRGBA(3, 2).r(), dim.r()));
+    assertTrue(IS_SORTA_EQUAL(img2->getRGBA(3, 2).g(), dim.g()));
+    assertTrue(IS_SORTA_EQUAL(img2->getRGBA(3, 2).b(), dim.b()));
+    assertTrue(IS_SORTA_EQUAL(img2->getRGBA(3, 2).a(), dim.a()));
+
+    ::remove((getLoadPrefix() + "/test.exr").c_str());
+    delete img;
+    delete img2;
+  }
+};
+
 int main(int argc, char *argv[]) {
   TestSuite suite;
   suite.add("RGBA", new test_rgba());
@@ -272,6 +302,9 @@ int main(int argc, char *argv[]) {
   }
   if (Image::supportsFormat(".jpg")) {
     suite.add("JPEG", new test_jpg());
+  }
+  if (Image::supportsFormat(".exr")) {
+    suite.add("OpenEXR", new test_openexr());
   }
   suite.run();
   suite.printStatus();

--- a/test/testimage.cpp
+++ b/test/testimage.cpp
@@ -165,6 +165,18 @@ public:
     delete img;
     delete img2;
 
+    // LDR writers must clamp alpha before premultiplying. On macOS this
+    // exercises the same DarwinIO path used for JPEG output.
+    color = RGBA(0.1, 0.2, 0.3, 3.0);
+    img = new ImageImpl<double, 4>(1, 1);
+    img->setRGBA(0, 0, color);
+    img->save(getLoadPrefix() + "/test-clamped.png");
+    img2 = Image::load(getLoadPrefix() + "/test-clamped.png");
+    assertEqualColor(img2->getRGBA(0, 0), color.clamped());
+    ::remove((getLoadPrefix() + "/test-clamped.png").c_str());
+    delete img;
+    delete img2;
+
     // Load 24 bit png
     img = Image::load(getLoadPrefix() + "/gfx/rgb.png");
     img->save(getLoadPrefix() + "/rgb-kaj.png");


### PR DESCRIPTION
Adds optional OpenEXR-backed .exr image loading and saving. OpenEXR is detected at configure time and only compiled/linked when available; without it, .exr is not advertised as a supported format.

The EXR writer preserves HDR values by avoiding the old global Image::save() clipping step. LDR writers now clamp during byte conversion instead.

Fixes #19

Verified locally:
- cmake --build build --target raygay testimage
- ctest --test-dir build --output-on-failure
- ../build/testimage from test/ shows OpenEXR Success: 10/10
- build/raygay -v lists OpenEXR
- cmake -S . -B /private/tmp/raygay-no-openexr -G Ninja -DCMAKE_DISABLE_FIND_PACKAGE_OpenEXR=TRUE
- cmake --build /private/tmp/raygay-no-openexr --target raygay testimage
- ctest --test-dir /private/tmp/raygay-no-openexr -R testimage --output-on-failure
- /private/tmp/raygay-no-openexr/raygay -v does not list OpenEXR