### PR TITLE
Clamp sphere UV acos inputs

### DIFF
--- a/src/objects/sphere.cpp
+++ b/src/objects/sphere.cpp
@@ -14,6 +14,16 @@
 
 using namespace std;
 
+static inline double clampAcosArgument(double x) {
+  if (x < -1.0) {
+    return -1.0;
+  }
+  if (x > 1.0) {
+    return 1.0;
+  }
+  return x;
+}
+
 Sphere::Sphere(const Vector &c, double r, const Material *mat) : Solid(mat) {
   assert(r > 0);
   center = c;
@@ -151,15 +161,15 @@ AABox Sphere::getContainedBox() const {
 // See http://astronomy.swin.edu.au/~pbourke/texture/spheremap/
 Vector2 Sphere::getUV(const Vector &p) const {
   double u, v;
-  v = acos(p[1]) / M_PI;
+  v = acos(clampAcosArgument(p[1])) / M_PI;
   if (IS_ZERO(sin((v)*M_PI))) {
     u = double(0.5);
     return Vector2(u, v);
   }
   if (p[2] <= 0.0) {
-    u = acos(p[0] / (sin((v)*M_PI))) / M_2PI;
+    u = acos(clampAcosArgument(p[0] / (sin((v)*M_PI)))) / M_2PI;
   } else {
-    u = 1 - (acos(p[0] / (sin((v)*M_PI))) / M_2PI);
+    u = 1 - (acos(clampAcosArgument(p[0] / (sin((v)*M_PI)))) / M_2PI);
   }
   return Vector2(u, v);
 }

--- a/test/testobjects.cpp
+++ b/test/testobjects.cpp
@@ -3,6 +3,7 @@
 #endif
 
 #include <cassert>
+#include <cmath>
 #include <cstdlib>
 #include <iostream>
 
@@ -166,6 +167,12 @@ public:
     assertEqualF(s.signedDistance(Vector(0, 0, -8)), -2);
     assertEqualF(s.signedDistance(Vector(0, 0, -12)), 2);
     assertEqualF(s.signedDistance(Vector(0, 12, 0)), 2);
+
+    Vector2 uv = s.getUV(
+        Vector(0.73386099292106322, -0.67929967103547995,
+               -2.3212565753993885e-09));
+    assertTrue(isfinite(uv[0]));
+    assertTrue(isfinite(uv[1]));
 
     s = Sphere(Vector(0, 0, 0), 60.0, m);
 


### PR DESCRIPTION
Fixes a NaN in sphere/environment UV mapping that showed up as a black pixel/box in `plate-spiral.scm`.

The problematic background ray missed scene geometry, hit the environment sphere, and then `Sphere::getUV()` computed `acos()` on a value that could drift just outside `[-1, 1]` due to floating-point rounding. That produced NaN UVs, which propagated to RGB and became black when written to image formats.

Changes:
- Clamp both sphere UV `acos()` inputs to `[-1, 1]`.
- Add a regression check using the normal from the failing `plate-spiral.scm` sample.

Verification:
- `cmake --build build --target testobjects`
- `../build/testobjects` from `test/`
- Temporary probe of subpixel `(497.5, 458.5)` in `plate-spiral.scm`: previously `(nan,nan,nan,1)`, now a normal background color.
