### PR TITLE
Use generic clamp for sphere UV mapping

### DIFF
--- a/src/math/functions.h
+++ b/src/math/functions.h
@@ -19,6 +19,8 @@ public:
   static double bernsteinPolynomial(uint32_t i, uint32_t n, double t);
   /// Clamps a to the [0,1] interval.
   static double clamp(double a);
+  /// Clamps a to the [min,max] interval.
+  static double clamp(double a, double min, double max);
 
   /// Solves quartic equation
   static int solveQuartic(double A, double B, double C, double D,
@@ -51,10 +53,14 @@ public:
 };
 
 inline double Math::clamp(double a) {
-  if (a > double(1)) {
-    return double(1);
-  } else if (a < double(0)) {
-    return double(0);
+  return clamp(a, double(0), double(1));
+}
+
+inline double Math::clamp(double a, double min, double max) {
+  if (a > max) {
+    return max;
+  } else if (a < min) {
+    return min;
   } else {
     return a;
   }

--- a/src/math/testmath.cpp
+++ b/src/math/testmath.cpp
@@ -509,6 +509,9 @@ public:
     assertTrue(Math::clamp(1.0) == 1.0);
     assertTrue(Math::clamp(-0.5) == 0.0);
     assertTrue(Math::clamp(1.5) == 1.0);
+    assertTrue(Math::clamp(0.5, -1.0, 1.0) == 0.5);
+    assertTrue(Math::clamp(-1.5, -1.0, 1.0) == -1.0);
+    assertTrue(Math::clamp(1.5, -1.0, 1.0) == 1.0);
   }
 };
 

--- a/src/objects/sphere.cpp
+++ b/src/objects/sphere.cpp
@@ -6,6 +6,7 @@
 #include "image/rgb.h"
 #include "intersection.h"
 #include "materials/material.h"
+#include "math/functions.h"
 #include "math/matrix.h"
 #include "math/vector2.h"
 #include "object.h"
@@ -13,16 +14,6 @@
 #include "sphere.h"
 
 using namespace std;
-
-static inline double clampAcosArgument(double x) {
-  if (x < -1.0) {
-    return -1.0;
-  }
-  if (x > 1.0) {
-    return 1.0;
-  }
-  return x;
-}
 
 Sphere::Sphere(const Vector &c, double r, const Material *mat) : Solid(mat) {
   assert(r > 0);
@@ -161,15 +152,16 @@ AABox Sphere::getContainedBox() const {
 // See http://astronomy.swin.edu.au/~pbourke/texture/spheremap/
 Vector2 Sphere::getUV(const Vector &p) const {
   double u, v;
-  v = acos(clampAcosArgument(p[1])) / M_PI;
+  v = acos(Math::clamp(p[1], -1.0, 1.0)) / M_PI;
   if (IS_ZERO(sin((v)*M_PI))) {
     u = double(0.5);
     return Vector2(u, v);
   }
   if (p[2] <= 0.0) {
-    u = acos(clampAcosArgument(p[0] / (sin((v)*M_PI)))) / M_2PI;
+    u = acos(Math::clamp(p[0] / (sin((v)*M_PI)), -1.0, 1.0)) / M_2PI;
   } else {
-    u = 1 - (acos(clampAcosArgument(p[0] / (sin((v)*M_PI)))) / M_2PI);
+    u =
+        1 - (acos(Math::clamp(p[0] / (sin((v)*M_PI)), -1.0, 1.0)) / M_2PI);
   }
   return Vector2(u, v);
 }


### PR DESCRIPTION
Fixes #46.

Replaces the local `clampAcosArgument()` helper in `Sphere::getUV()` with a generic `Math::clamp(value, min, max)` overload.

Changes:
- Add `Math::clamp(double value, double min, double max)`.
- Keep the existing `Math::clamp(value)` behavior by delegating to the new overload with `[0, 1]`.
- Use the generic clamp for sphere UV `acos()` inputs.
- Extend the math clamp test with `[-1, 1]` coverage.

Verification:
- `cmake --build build --target testmath testobjects`
